### PR TITLE
test(#7): add genre repository integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
             <version>2.4.240</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+            <version>4.0.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImplTest.java
@@ -1,0 +1,53 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaGenreRepository;
+import ru.jerael.booktracker.backend.data.mapper.GenreMapper;
+import ru.jerael.booktracker.backend.domain.model.Genre;
+import java.util.List;
+import java.util.Optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@Import({GenreRepositoryImpl.class, GenreMapper.class})
+class GenreRepositoryImplTest {
+
+    @Autowired
+    private GenreRepositoryImpl genreRepository;
+
+    @Autowired
+    private JpaGenreRepository jpaGenreRepository;
+
+    @Test
+    void getGenres_ShouldReturnAllGenres() {
+        GenreEntity entity1 = new GenreEntity();
+        entity1.setName("adventure");
+        GenreEntity entity2 = new GenreEntity();
+        entity2.setName("action");
+        jpaGenreRepository.saveAll(List.of(entity1, entity2));
+
+        List<Genre> result = genreRepository.getGenres();
+
+        assertEquals(2, result.size());
+        assertThat(result).extracting(Genre::name).containsExactlyInAnyOrder("adventure", "action");
+    }
+
+    @Test
+    void getGenreById_WhenExists_ShouldReturnGenre() {
+        GenreEntity entity = new GenreEntity();
+        entity.setName("adventure");
+        GenreEntity savedEntity = jpaGenreRepository.save(entity);
+
+        Optional<Genre> result = genreRepository.getGenreById(savedEntity.getId());
+
+        assertTrue(result.isPresent());
+        assertEquals("adventure", result.get().name());
+        assertEquals(savedEntity.getId(), result.get().id());
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Added `GenreRepositoryImplTest` integration tests.
- Added new dependency `spring-boot-starter-data-jpa-test` for jpa tests in `pom.xml` file.

### Related tickets

#7

### Screenshots

not applicable

### How to test

Run `mvnw test`.

### Additional notes

no additional info
