### PR TITLE
refactor: use Instant for createdAt field in BookResponse

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/api/dto/book/BookResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/api/dto/book/BookResponse.java
@@ -2,6 +2,7 @@ package ru.jerael.booktracker.backend.api.dto.book;
 
 import jakarta.annotation.Nullable;
 import ru.jerael.booktracker.backend.api.dto.genre.GenreResponse;
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -11,6 +12,6 @@ public record BookResponse(
     String author,
     @Nullable String coverUrl,
     String status,
-    Long createdAt,
+    Instant createdAt,
     Set<GenreResponse> genres
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/api/mapper/BookApiMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/api/mapper/BookApiMapper.java
@@ -27,7 +27,7 @@ public class BookApiMapper {
             book.author(),
             book.coverUrl(),
             book.status().getValue(),
-            book.createdAt().toEpochMilli(),
+            book.createdAt(),
             genreApiMapper.toResponses(book.genres())
         );
     }

--- a/src/test/java/ru/jerael/booktracker/backend/api/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/api/controller/BookControllerTest.java
@@ -82,8 +82,8 @@ class BookControllerTest {
     @Test
     void getAll_ShouldReturnListOfBookResponses() {
         Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
-        BookResponse bookResponse = new BookResponse(id, title, author, null, status.getValue(),
-            createdAt.toEpochMilli(), Collections.emptySet());
+        BookResponse bookResponse =
+            new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
         PageResult<Book> pageResult = new PageResult<>(List.of(book), 10, 0, 1, 1);
         when(getBooksUseCase.execute(any(PageQuery.class))).thenReturn(pageResult);
         when(bookApiMapper.toResponse(book)).thenReturn(bookResponse);
@@ -137,8 +137,7 @@ class BookControllerTest {
         BookDetailsUpdate data = new BookDetailsUpdate("new title", null, BookStatus.READING, null);
         Book book = new Book(id, "new title", author, null, BookStatus.READING, createdAt, Collections.emptySet());
         BookResponse bookResponse =
-            new BookResponse(id, "new title", author, null, "reading", createdAt.toEpochMilli(),
-                Collections.emptySet());
+            new BookResponse(id, "new title", author, null, "reading", createdAt, Collections.emptySet());
         when(bookApiMapper.toDomain(request)).thenReturn(data);
         when(updateBookDetailsUseCase.execute(id, data)).thenReturn(book);
         when(bookApiMapper.toResponse(book)).thenReturn(bookResponse);
@@ -164,8 +163,7 @@ class BookControllerTest {
         BookCreation data = new BookCreation(title, author, Set.of(1, 2));
         Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
         BookResponse bookResponse =
-            new BookResponse(id, title, author, null, status.getValue(), createdAt.toEpochMilli(),
-                Collections.emptySet());
+            new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
         when(bookApiMapper.toDomain(request)).thenReturn(data);
         when(createBookUseCase.execute(data)).thenReturn(book);
         when(bookApiMapper.toResponse(book)).thenReturn(bookResponse);
@@ -198,7 +196,7 @@ class BookControllerTest {
         UploadCover data = new UploadCover(id, MediaType.IMAGE_JPEG_VALUE, null);
         Book book = new Book(id, title, author, coverUrl, status, createdAt, null);
         BookResponse bookResponse =
-            new BookResponse(id, title, author, coverUrl, status.getValue(), createdAt.toEpochMilli(), null);
+            new BookResponse(id, title, author, coverUrl, status.getValue(), createdAt, null);
         when(uploadCoverApiMapper.toDomain(id, mockMultipartFile)).thenReturn(data);
         when(uploadCoverUseCase.execute(data)).thenReturn(book);
         when(bookApiMapper.toResponse(book)).thenReturn(bookResponse);

--- a/src/test/java/ru/jerael/booktracker/backend/api/mapper/BookApiMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/api/mapper/BookApiMapperTest.java
@@ -40,7 +40,7 @@ class BookApiMapperTest {
         assertEquals(author, bookResponse.author());
         assertEquals(coverUrl, bookResponse.coverUrl());
         assertEquals(status.getValue(), bookResponse.status());
-        assertEquals(createdAt.toEpochMilli(), bookResponse.createdAt());
+        assertEquals(createdAt, bookResponse.createdAt());
         assertTrue(bookResponse.genres().containsAll(genreApiMapper.toResponses(genres)));
     }
 


### PR DESCRIPTION
### What does this PR do?

- Replaced `Long` (epoch milliseconds) with `java.time.Instant` in `BookResponse`.
- Removed map `toEpochMilli` in `BookApiMapper`.

Tests:
- Updated `BookControllerTest` and `BookApiMapperTest` to assert `Instant` values instead of `Long`.

### Related tickets

Closes #31

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the database: `docker compose up -d db`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```

### Additional notes

no additional info
