### PR TITLE
refactor: change cover upload method to POST

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/api/controller/BookController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/api/controller/BookController.java
@@ -92,7 +92,7 @@ public class BookController {
         return bookApiMapper.toResponse(book);
     }
 
-    @PatchMapping("/{id}/cover")
+    @PostMapping("/{id}/cover")
     public BookResponse uploadCover(
         @PathVariable UUID id,
         @RequestParam(BookRules.COVER_FIELD_NAME) MultipartFile file

--- a/src/test/java/ru/jerael/booktracker/backend/api/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/api/controller/BookControllerTest.java
@@ -206,7 +206,7 @@ class BookControllerTest {
         when(bookApiMapper.toResponse(book)).thenReturn(bookResponse);
 
         assertThat(
-            mockMvcTester.patch().uri("/api/v1/books/" + id + "/cover")
+            mockMvcTester.post().uri("/api/v1/books/" + id + "/cover")
                 .multipart()
                 .file(mockMultipartFile)
         )


### PR DESCRIPTION
### What does this PR do?

Updates the cover upload endpoint to follow REST standards.
- Modified `BookController` to use `@PostMapping`.

Tests:
- Updated `BookControllerTest`.

### Related tickets

Closes #41

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the database: `docker compose up -d db minio`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```

### Additional notes

no additional info
