### PR TITLE
refactor: rename notFound methods in Domain ExceptionFactories

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -30,7 +30,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
             Set<Integer> missingIds = data.genreIds().stream()
                 .filter(id -> !foundIds.contains(id))
                 .collect(Collectors.toSet());
-            throw GenreExceptionFactory.notFound(missingIds);
+            throw GenreExceptionFactory.genresNotFound(missingIds);
         }
         Book newBook = new Book(
             null,

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImpl.java
@@ -19,7 +19,7 @@ public class DeleteBookUseCaseImpl implements DeleteBookUseCase {
     @Override
     @Transactional
     public void execute(UUID id) {
-        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.notFound(id));
+        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
         String coverFileName = book.coverFileName();
         bookRepository.deleteById(id);
         if (coverFileName != null) {

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
@@ -19,7 +19,7 @@ public class DeleteCoverUseCaseImpl implements DeleteCoverUseCase {
     @Override
     @Transactional
     public void execute(UUID bookId) {
-        Book book = bookRepository.findById(bookId).orElseThrow(() -> BookExceptionFactory.notFound(bookId));
+        Book book = bookRepository.findById(bookId).orElseThrow(() -> BookExceptionFactory.bookNotFound(bookId));
         if (book.coverFileName() == null) return;
 
         Book updatedBook = new Book(

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImpl.java
@@ -17,6 +17,6 @@ public class GetBookByIdUseCaseImpl implements GetBookByIdUseCase {
     @Override
     @Transactional(readOnly = true)
     public Book execute(UUID id) {
-        return bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.notFound(id));
+        return bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImpl.java
@@ -20,7 +20,7 @@ public class GetBookCoverUseCaseImpl implements GetBookCoverUseCase {
     @Override
     @Transactional(readOnly = true)
     public ImageFile execute(UUID id) {
-        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.notFound(id));
+        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
         if (book.coverFileName() == null || book.coverFileName().isBlank()) {
             throw BookExceptionFactory.coverNotFound(id);
         }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
@@ -24,7 +24,7 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
     @Override
     @Transactional
     public Book execute(UUID id, BookDetailsUpdate data) {
-        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.notFound(id));
+        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
 
         Set<Genre> updatedGenres = book.genres();
         if (data.genreIds() != null) {
@@ -34,7 +34,7 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
                 Set<Integer> missingIds = data.genreIds().stream()
                     .filter(genreId -> !foundIds.contains(genreId))
                     .collect(Collectors.toSet());
-                throw GenreExceptionFactory.notFound(missingIds);
+                throw GenreExceptionFactory.genresNotFound(missingIds);
             }
         }
 

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
@@ -31,7 +31,7 @@ public class UploadCoverUseCaseImpl implements UploadCoverUseCase {
     @Transactional
     public Book execute(UUID bookId, UploadCover data) {
         Book book =
-            bookRepository.findById(bookId).orElseThrow(() -> BookExceptionFactory.notFound(bookId));
+            bookRepository.findById(bookId).orElseThrow(() -> BookExceptionFactory.bookNotFound(bookId));
         if (!ImageRules.ALLOWED_MIME_TYPES.contains(data.contentType())) {
             throw FileValidationExceptionFactory.unsupportedFileContentType(
                 data.contentType(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/genre/GetGenreByIdUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/genre/GetGenreByIdUseCaseImpl.java
@@ -14,6 +14,6 @@ public class GetGenreByIdUseCaseImpl implements GetGenreByIdUseCase {
 
     @Override
     public Genre execute(Integer id) {
-        return genreRepository.findById(id).orElseThrow(() -> GenreExceptionFactory.notFound(id));
+        return genreRepository.findById(id).orElseThrow(() -> GenreExceptionFactory.genreNotFound(id));
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/BookExceptionFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/BookExceptionFactory.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class BookExceptionFactory {
-    public static NotFoundException notFound(UUID id) { // TODO: rename to bookNotFound
+    public static NotFoundException bookNotFound(UUID id) {
         return new NotFoundException(
             BookErrorCode.BOOK_NOT_FOUND,
             "Book with id " + id + " was not found"

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/GenreExceptionFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/GenreExceptionFactory.java
@@ -5,14 +5,14 @@ import ru.jerael.booktracker.backend.domain.exception.code.GenreErrorCode;
 import java.util.Set;
 
 public class GenreExceptionFactory {
-    public static NotFoundException notFound(Integer id) {
+    public static NotFoundException genreNotFound(Integer id) {
         return new NotFoundException(
             GenreErrorCode.GENRE_NOT_FOUND,
             "Genre not found with id: " + id
         );
     }
 
-    public static NotFoundException notFound(Set<Integer> ids) {
+    public static NotFoundException genresNotFound(Set<Integer> ids) {
         return new NotFoundException(
             GenreErrorCode.GENRE_NOT_FOUND,
             "Genres not found with ids: " + ids

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -117,7 +117,7 @@ class BookControllerTest {
     @Test
     void getById_WhenExceptionThrown_ShouldReturnNotFound() {
         UUID id = UUID.fromString("31d3f5e3-7faf-4678-a3cf-4657d8875a82");
-        when(getBookByIdUseCase.execute(id)).thenThrow(BookExceptionFactory.notFound(id));
+        when(getBookByIdUseCase.execute(id)).thenThrow(BookExceptionFactory.bookNotFound(id));
 
         assertThat(mockMvcTester.get().uri("/api/v1/books/" + id))
             .hasStatus(HttpStatus.NOT_FOUND)

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/GenreControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/GenreControllerTest.java
@@ -52,7 +52,7 @@ class GenreControllerTest {
     @Test
     void getById_WhenExceptionThrown_ShouldReturnNotFound() {
         Integer genreId = 5555;
-        when(getGenreByIdUseCase.execute(genreId)).thenThrow(GenreExceptionFactory.notFound(genreId));
+        when(getGenreByIdUseCase.execute(genreId)).thenThrow(GenreExceptionFactory.genreNotFound(genreId));
 
         restTestClient.get().uri("/api/v1/genres/" + genreId)
             .exchange()

--- a/src/test/java/ru/jerael/booktracker/backend/web/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/exception/handler/GlobalExceptionHandlerTest.java
@@ -49,7 +49,7 @@ class GlobalExceptionHandlerTest {
 
         @GetMapping("/test/not-found")
         void notFound() {
-            throw BookExceptionFactory.notFound(id);
+            throw BookExceptionFactory.bookNotFound(id);
         }
 
         @GetMapping("/test/validation")


### PR DESCRIPTION
### What does this PR do?

- Renamed `notFound` to `bookNotFound` in `BookExceptionFactory`.
- Renamed `notFound(Integer id)` to `genreNotFound(Integer id)` in `GenreExceptionFactory`.
- Renamed `notFound(Set<Integer> ids)` to `genresNotFound(Set<Integer> ids)` in `GenreExceptionFactory`.

### Related tickets

Closes #51

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```

### Additional notes

no additional info
