### PR TITLE
ops: add CI pipeline for docker build and push to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
 
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
### What does this PR do?

CI pipeline for Docker image build and push to Docker Hub.
- Added `.github/workflows/docker-publish.yml` to handle the Docker lifecycle.
- Workflow triggers on `push` to `main` branch, new tag starting with `v*`, on `pull request` to `main` (without push to Docker Hub).
- Uses new github repository secrets: `DOCKER_USERNAME` and `DOCKER_PASSWORD`.

### Related tickets

Closes #61

### Screenshots

not applicable

### How to test

1. Set repository secrets in GitHub.
2. Push or merge to `main`.
3. Check `Actions` for `Docker` job.
4. Verify that a new image with correct version tag added to Docker Hub Repository.

### Additional notes

no additional info
