### PR TITLE
ops: use env_file for configuration in Docker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,18 +34,12 @@ services:
     depends_on:
       - db
       - minio
+    env_file:
+      - .env
     environment:
       DB_HOST: db
       POSTGRES_PORT: 5432
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-
       MINIO_URL: http://minio:9000
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-      MINIO_URL_EXPIRY: ${MINIO_URL_EXPIRY}
-      MINIO_COVERS_BUCKET: ${MINIO_COVERS_BUCKET}
     networks:
       - app-network
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>ru.jerael</groupId>
     <artifactId>booktracker-backend</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <name>booktracker-backend</name>
     <description>BookTracker Backend</description>
 


### PR DESCRIPTION
### What does this PR do?

- Integrated `env_file` into `docker-compose.prod.yml` to automatically inject all `.env` variables.
- Cleaned up the `environment` block to only include service-to-service routing.
- Bumped version to `0.1.1`.

### Related tickets

Closes #67

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
