### PR TITLE
feat: prepare for multiple users

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -13,6 +13,7 @@ import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
 import ru.jerael.booktracker.backend.domain.usecase.book.CreateBookUseCase;
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,7 +24,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
 
     @Override
     @Transactional
-    public Book execute(BookCreation data) {
+    public Book execute(BookCreation data, UUID userId) {
         Set<Genre> genres = genreRepository.findAllById(data.genreIds());
         if (genres.size() != data.genreIds().size()) {
             Set<Integer> foundIds = genres.stream().map(Genre::id).collect(Collectors.toSet());
@@ -41,6 +42,6 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
             Instant.now(),
             genres
         );
-        return bookRepository.save(newBook);
+        return bookRepository.save(newBook, userId);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImpl.java
@@ -18,10 +18,11 @@ public class DeleteBookUseCaseImpl implements DeleteBookUseCase {
 
     @Override
     @Transactional
-    public void execute(UUID id) {
-        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
+    public void execute(UUID id, UUID userId) {
+        Book book =
+            bookRepository.findByIdAndUserId(id, userId).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
         String coverFileName = book.coverFileName();
-        bookRepository.deleteById(id);
+        bookRepository.deleteByIdAndUserId(id, userId);
         if (coverFileName != null) {
             bookCoverStorage.delete(coverFileName);
         }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
@@ -18,8 +18,9 @@ public class DeleteCoverUseCaseImpl implements DeleteCoverUseCase {
 
     @Override
     @Transactional
-    public void execute(UUID bookId) {
-        Book book = bookRepository.findById(bookId).orElseThrow(() -> BookExceptionFactory.bookNotFound(bookId));
+    public void execute(UUID bookId, UUID userId) {
+        Book book = bookRepository.findByIdAndUserId(bookId, userId)
+            .orElseThrow(() -> BookExceptionFactory.bookNotFound(bookId));
         if (book.coverFileName() == null) return;
 
         Book updatedBook = new Book(
@@ -31,7 +32,7 @@ public class DeleteCoverUseCaseImpl implements DeleteCoverUseCase {
             book.createdAt(),
             book.genres()
         );
-        bookRepository.save(updatedBook);
+        bookRepository.save(updatedBook, userId);
         bookCoverStorage.delete(book.coverFileName());
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImpl.java
@@ -16,7 +16,7 @@ public class GetBookByIdUseCaseImpl implements GetBookByIdUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public Book execute(UUID id) {
-        return bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
+    public Book execute(UUID id, UUID userId) {
+        return bookRepository.findByIdAndUserId(id, userId).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImpl.java
@@ -19,8 +19,9 @@ public class GetBookCoverUseCaseImpl implements GetBookCoverUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public ImageFile execute(UUID id) {
-        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
+    public ImageFile execute(UUID id, UUID userId) {
+        Book book =
+            bookRepository.findByIdAndUserId(id, userId).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
         if (book.coverFileName() == null || book.coverFileName().isBlank()) {
             throw BookExceptionFactory.coverNotFound(id);
         }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBooksUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/GetBooksUseCaseImpl.java
@@ -8,6 +8,7 @@ import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.usecase.book.GetBooksUseCase;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,7 +17,7 @@ public class GetBooksUseCaseImpl implements GetBooksUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResult<Book> execute(PageQuery query) {
-        return bookRepository.findAll(query);
+    public PageResult<Book> execute(PageQuery query, UUID userId) {
+        return bookRepository.findAllByUserId(query, userId);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
@@ -23,8 +23,9 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
 
     @Override
     @Transactional
-    public Book execute(UUID id, BookDetailsUpdate data) {
-        Book book = bookRepository.findById(id).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
+    public Book execute(UUID id, UUID userId, BookDetailsUpdate data) {
+        Book book =
+            bookRepository.findByIdAndUserId(id, userId).orElseThrow(() -> BookExceptionFactory.bookNotFound(id));
 
         Set<Genre> updatedGenres = book.genres();
         if (data.genreIds() != null) {
@@ -47,6 +48,6 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
             book.createdAt(),
             updatedGenres
         );
-        return bookRepository.save(updatedBook);
+        return bookRepository.save(updatedBook, userId);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
@@ -29,9 +29,10 @@ public class UploadCoverUseCaseImpl implements UploadCoverUseCase {
 
     @Override
     @Transactional
-    public Book execute(UUID bookId, UploadCover data) {
+    public Book execute(UUID bookId, UUID userId, UploadCover data) {
         Book book =
-            bookRepository.findById(bookId).orElseThrow(() -> BookExceptionFactory.bookNotFound(bookId));
+            bookRepository.findByIdAndUserId(bookId, userId)
+                .orElseThrow(() -> BookExceptionFactory.bookNotFound(bookId));
         if (!ImageRules.ALLOWED_MIME_TYPES.contains(data.contentType())) {
             throw FileValidationExceptionFactory.unsupportedFileContentType(
                 data.contentType(),
@@ -59,7 +60,7 @@ public class UploadCoverUseCaseImpl implements UploadCoverUseCase {
             book.createdAt(),
             book.genres()
         );
-        Book savedBook = bookRepository.save(updatedBook);
+        Book savedBook = bookRepository.save(updatedBook, userId);
         if (oldCoverFileName != null && !oldCoverFileName.equals(newCoverFileName)) {
             try {
                 bookCoverStorage.delete(oldCoverFileName);

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
@@ -23,6 +23,9 @@ public class BookEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
     @Column(name = "title", length = BookRules.TITLE_MAX_LENGTH, nullable = false)
     private String title;
 

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaBookRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaBookRepository.java
@@ -1,9 +1,18 @@
 package ru.jerael.booktracker.backend.data.db.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface JpaBookRepository extends JpaRepository<BookEntity, UUID> {}
+public interface JpaBookRepository extends JpaRepository<BookEntity, UUID> {
+    Page<BookEntity> findAllByUserId(Pageable pageable, UUID userId);
+
+    Optional<BookEntity> findByIdAndUserId(UUID id, UUID userId);
+
+    void deleteByIdAndUserId(UUID id, UUID userId);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImpl.java
@@ -52,6 +52,7 @@ public class BookRepositoryImpl implements BookRepository {
     @Override
     public Book save(Book book) {
         BookEntity entity = bookDataMapper.toEntity(book);
+        entity.setUserId(UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e")); // TODO: REMOVE THIS
         BookEntity savedEntity = jpaBookRepository.save(entity);
         return bookDataMapper.toDomain(savedEntity);
     }

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImpl.java
@@ -25,7 +25,7 @@ public class BookRepositoryImpl implements BookRepository {
     private final BookDataMapper bookDataMapper;
 
     @Override
-    public PageResult<Book> findAll(PageQuery query) {
+    public PageResult<Book> findAllByUserId(PageQuery query, UUID userId) {
         int page = query != null ? query.page() : 0;
         int size = query != null ? query.size() : 0;
         String sortBy = query != null ? query.sortBy() : PaginationRules.DEFAULT_SORT_FIELD;
@@ -34,7 +34,7 @@ public class BookRepositoryImpl implements BookRepository {
             : Sort.Direction.DESC;
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
-        Page<BookEntity> entities = jpaBookRepository.findAll(pageable);
+        Page<BookEntity> entities = jpaBookRepository.findAllByUserId(pageable, userId);
         return new PageResult<>(
             entities.getContent().stream().map(bookDataMapper::toDomain).toList(),
             entities.getSize(),
@@ -45,20 +45,20 @@ public class BookRepositoryImpl implements BookRepository {
     }
 
     @Override
-    public Optional<Book> findById(UUID id) {
-        return jpaBookRepository.findById(id).map(bookDataMapper::toDomain);
+    public Optional<Book> findByIdAndUserId(UUID id, UUID userId) {
+        return jpaBookRepository.findByIdAndUserId(id, userId).map(bookDataMapper::toDomain);
     }
 
     @Override
-    public Book save(Book book) {
+    public Book save(Book book, UUID userId) {
         BookEntity entity = bookDataMapper.toEntity(book);
-        entity.setUserId(UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e")); // TODO: REMOVE THIS
+        entity.setUserId(userId); // TODO: REMOVE THIS
         BookEntity savedEntity = jpaBookRepository.save(entity);
         return bookDataMapper.toDomain(savedEntity);
     }
 
     @Override
-    public void deleteById(UUID id) {
-        jpaBookRepository.deleteById(id);
+    public void deleteByIdAndUserId(UUID id, UUID userId) {
+        jpaBookRepository.deleteByIdAndUserId(id, userId);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/BookRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/BookRepository.java
@@ -7,11 +7,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface BookRepository {
-    PageResult<Book> findAll(PageQuery query);
+    PageResult<Book> findAllByUserId(PageQuery query, UUID userId);
 
-    Optional<Book> findById(UUID id);
+    Optional<Book> findByIdAndUserId(UUID id, UUID userId);
 
-    Book save(Book book);
+    Book save(Book book, UUID userId);
 
-    void deleteById(UUID id);
+    void deleteByIdAndUserId(UUID id, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/CreateBookUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/CreateBookUseCase.java
@@ -2,7 +2,8 @@ package ru.jerael.booktracker.backend.domain.usecase.book;
 
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
+import java.util.UUID;
 
 public interface CreateBookUseCase {
-    Book execute(BookCreation data);
+    Book execute(BookCreation data, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/DeleteBookUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/DeleteBookUseCase.java
@@ -3,5 +3,5 @@ package ru.jerael.booktracker.backend.domain.usecase.book;
 import java.util.UUID;
 
 public interface DeleteBookUseCase {
-    void execute(UUID id);
+    void execute(UUID id, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/DeleteCoverUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/DeleteCoverUseCase.java
@@ -3,5 +3,5 @@ package ru.jerael.booktracker.backend.domain.usecase.book;
 import java.util.UUID;
 
 public interface DeleteCoverUseCase {
-    void execute(UUID bookId);
+    void execute(UUID bookId, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/GetBookByIdUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/GetBookByIdUseCase.java
@@ -4,5 +4,5 @@ import ru.jerael.booktracker.backend.domain.model.book.Book;
 import java.util.UUID;
 
 public interface GetBookByIdUseCase {
-    Book execute(UUID id);
+    Book execute(UUID id, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/GetBookCoverUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/GetBookCoverUseCase.java
@@ -4,5 +4,5 @@ import ru.jerael.booktracker.backend.domain.model.image.ImageFile;
 import java.util.UUID;
 
 public interface GetBookCoverUseCase {
-    ImageFile execute(UUID id);
+    ImageFile execute(UUID id, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/GetBooksUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/GetBooksUseCase.java
@@ -3,7 +3,8 @@ package ru.jerael.booktracker.backend.domain.usecase.book;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
+import java.util.UUID;
 
 public interface GetBooksUseCase {
-    PageResult<Book> execute(PageQuery query);
+    PageResult<Book> execute(PageQuery query, UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/UpdateBookDetailsUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/UpdateBookDetailsUseCase.java
@@ -5,5 +5,5 @@ import ru.jerael.booktracker.backend.domain.model.book.BookDetailsUpdate;
 import java.util.UUID;
 
 public interface UpdateBookDetailsUseCase {
-    Book execute(UUID id, BookDetailsUpdate data);
+    Book execute(UUID id, UUID userId, BookDetailsUpdate data);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/UploadCoverUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/book/UploadCoverUseCase.java
@@ -5,5 +5,5 @@ import ru.jerael.booktracker.backend.domain.model.book.UploadCover;
 import java.util.UUID;
 
 public interface UploadCoverUseCase {
-    Book execute(UUID bookId, UploadCover data);
+    Book execute(UUID bookId, UUID userId, UploadCover data);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/BookController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/BookController.java
@@ -65,7 +65,8 @@ public class BookController {
             sortBy,
             direction
         );
-        PageResult<Book> books = getBooksUseCase.execute(query);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        PageResult<Book> books = getBooksUseCase.execute(query, userId);
         PageResult<BookResponse> bookResponses = books.map(bookWebMapper::toResponse);
         Page<BookResponse> page = new PageImpl<>(
             bookResponses.content(),
@@ -78,7 +79,8 @@ public class BookController {
     @Operation(summary = "Get book by id")
     @GetMapping("/{id}")
     public BookResponse getById(@PathVariable UUID id) {
-        Book book = getBookByIdUseCase.execute(id);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        Book book = getBookByIdUseCase.execute(id, userId);
         return bookWebMapper.toResponse(book);
     }
 
@@ -86,14 +88,16 @@ public class BookController {
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteBook(@PathVariable UUID id) {
-        deleteBookUseCase.execute(id);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        deleteBookUseCase.execute(id, userId);
     }
 
     @Operation(summary = "Update book details")
     @PatchMapping("/{id}")
     public BookResponse updateDetails(@PathVariable UUID id, @Valid @RequestBody BookDetailsUpdateRequest request) {
         BookDetailsUpdate data = bookWebMapper.toDomain(request);
-        Book book = updateBookDetailsUseCase.execute(id, data);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        Book book = updateBookDetailsUseCase.execute(id, userId, data);
         return bookWebMapper.toResponse(book);
     }
 
@@ -102,7 +106,8 @@ public class BookController {
     @ResponseStatus(HttpStatus.CREATED)
     public BookResponse create(@Valid @RequestBody BookCreationRequest request) {
         BookCreation data = bookWebMapper.toDomain(request);
-        Book book = createBookUseCase.execute(data);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        Book book = createBookUseCase.execute(data, userId);
         return bookWebMapper.toResponse(book);
     }
 
@@ -114,7 +119,8 @@ public class BookController {
     ) {
         fileValidator.validate(file, BookRules.COVER_FIELD_NAME);
         UploadCover data = uploadCoverWebMapper.toDomain(file);
-        Book book = uploadCoverUseCase.execute(id, data);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        Book book = uploadCoverUseCase.execute(id, userId, data);
         return bookWebMapper.toResponse(book);
     }
 
@@ -122,13 +128,15 @@ public class BookController {
     @DeleteMapping("/{id}/cover")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteCover(@PathVariable UUID id) {
-        deleteCoverUseCase.execute(id);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        deleteCoverUseCase.execute(id, userId);
     }
 
     @Operation(summary = "Get book cover")
     @GetMapping("/{id}/cover")
     public ResponseEntity<Resource> getCover(@PathVariable UUID id) {
-        ImageFile imageFile = getBookCoverUseCase.execute(id);
+        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+        ImageFile imageFile = getBookCoverUseCase.execute(id, userId);
         return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "filename=\"" + imageFile.fileName() + "\"")
             .contentType(MediaType.parseMediaType(imageFile.contentType()))

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -9,3 +9,13 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/04__book_genres-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/05__rename-cover_url-field.yaml
+  - include:
+      file: classpath:/db/changelog/changes/06__users-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/07__add-archive-user-to-users.yaml
+  - include:
+      file: classpath:/db/changelog/changes/08__add-nullable-user_id-field-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/09__set-archive-user-id-to-all-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/10__set-user_id-not-null-in-books.yaml

--- a/src/main/resources/db/changelog/changes/06__users-schema.yaml
+++ b/src/main/resources/db/changelog/changes/06__users-schema.yaml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+  - changeSet:
+      id: 06__create-users-table
+      author: Jerael
+      comment: create users table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: users
+      changes:
+        - createTable:
+            tableName: users
+            columns:
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: email
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_users_email
+              - column:
+                  name: password_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: is_verified
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: users
+            columnNames: user_id
+            constraintName: pk_users

--- a/src/main/resources/db/changelog/changes/07__add-archive-user-to-users.yaml
+++ b/src/main/resources/db/changelog/changes/07__add-archive-user-to-users.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 07__add-archive-user-to-users-table
+      author: Jerael
+      comment: add archive user to users table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            sqlCheck:
+              expectedResult: 1
+              sql: SELECT COUNT(*) FROM users WHERE user_id = '2c5781ea-1bc2-4561-a83d-26106df2526e'
+      changes:
+        - insert:
+            tableName: users
+            columns:
+              - column:
+                  name: user_id
+                  value: 2c5781ea-1bc2-4561-a83d-26106df2526e
+              - column:
+                  name: email
+                  value: archive@example.com
+              - column:
+                  name: password_hash
+                  value: $argon2id$v=19$m=16,t=2,p=1$S2ZKYVBOdEt4OFJlODl1VQ$RWSvEp4uX/dyy4viKCnJLJBMPQGgydKkB8OOd+ZiTrc
+              - column:
+                  name: is_verified
+                  valueBoolean: true
+              - column:
+                  name: created_at
+                  valueDate: now()

--- a/src/main/resources/db/changelog/changes/08__add-nullable-user_id-field-in-books.yaml
+++ b/src/main/resources/db/changelog/changes/08__add-nullable-user_id-field-in-books.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 08__add-nullable-user_id-field-in-books-table
+      author: Jerael
+      comment: add nullable user_id field in books table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            columnExists:
+              tableName: books
+              columnName: user_id
+      changes:
+        - addColumn:
+            tableName: books
+            columns:
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+        - addForeignKeyConstraint:
+            baseTableName: books
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: user_id
+            constraintName: fk_books_user_id
+            onDelete: CASCADE

--- a/src/main/resources/db/changelog/changes/09__set-archive-user-id-to-all-books.yaml
+++ b/src/main/resources/db/changelog/changes/09__set-archive-user-id-to-all-books.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: 09__set-archive-user-id-to-all-books
+      author: Jerael
+      comment: set archive user id to all existing books
+      preconditions:
+        - onFail: MARK_RAN
+          columnExists:
+            tableName: books
+            columnName: user_id
+      changes:
+        - update:
+            tableName: books
+            where: user_id IS NULL
+            columns:
+              - column:
+                  name: user_id
+                  value: 2c5781ea-1bc2-4561-a83d-26106df2526e

--- a/src/main/resources/db/changelog/changes/10__set-user_id-not-null-in-books.yaml
+++ b/src/main/resources/db/changelog/changes/10__set-user_id-not-null-in-books.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 10__set-user_id-not-null-in-books
+      author: Jerael
+      comment: set user_id field not null in books
+      preconditions:
+        - onFail: HALT
+          columnExists:
+            tableName: books
+            columnName: user_id
+      changes:
+        - addNotNullConstraint:
+            tableName: books
+            columnName: user_id
+            columnDataType: uuid

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
@@ -31,6 +31,8 @@ class CreateBookUseCaseImplTest {
     @InjectMocks
     private CreateBookUseCaseImpl useCase;
 
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+
     @Test
     void execute_WhenAllGenresFound_ShouldCreateBookWithAllGenres() {
         UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
@@ -46,7 +48,7 @@ class CreateBookUseCaseImplTest {
         Set<Genre> genres = Set.of(genre1, genre2);
 
         when(genreRepository.findAllById(genreIds)).thenReturn(genres);
-        when(bookRepository.save(any())).thenAnswer(invocationOnMock -> {
+        when(bookRepository.save(any(), eq(userId))).thenAnswer(invocationOnMock -> {
             Book book = invocationOnMock.getArgument(0);
             return new Book(
                 id,
@@ -59,7 +61,7 @@ class CreateBookUseCaseImplTest {
             );
         });
 
-        Book result = useCase.execute(data);
+        Book result = useCase.execute(data, userId);
 
         assertNotNull(result);
         assertEquals(id, result.id());
@@ -70,7 +72,7 @@ class CreateBookUseCaseImplTest {
         verify(genreRepository).findAllById(genreIds);
 
         ArgumentCaptor<Book> bookArgumentCaptor = ArgumentCaptor.forClass(Book.class);
-        verify(bookRepository).save(bookArgumentCaptor.capture());
+        verify(bookRepository).save(bookArgumentCaptor.capture(), eq(userId));
 
         Book capturedBook = bookArgumentCaptor.getValue();
         assertNull(capturedBook.id());
@@ -87,7 +89,7 @@ class CreateBookUseCaseImplTest {
         Genre genre1 = new Genre(1, "action");
         when(genreRepository.findAllById(genreIds)).thenReturn(Set.of(genre1));
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(data));
-        verify(bookRepository, never()).save(any());
+        assertThrows(NotFoundException.class, () -> useCase.execute(data, userId));
+        verify(bookRepository, never()).save(any(), eq(userId));
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
@@ -30,6 +30,7 @@ class DeleteBookUseCaseImplTest {
     private DeleteBookUseCaseImpl useCase;
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.WANT_TO_READ;
@@ -37,9 +38,9 @@ class DeleteBookUseCaseImplTest {
 
     @Test
     void execute_WhenBookDoesNotExists_ShouldThrowNotFoundException() {
-        when(bookRepository.findById(id)).thenReturn(Optional.empty());
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(id));
+        assertThrows(NotFoundException.class, () -> useCase.execute(id, userId));
 
         verifyNoInteractions(bookCoverStorage);
     }
@@ -48,22 +49,22 @@ class DeleteBookUseCaseImplTest {
     void execute_WhenBookHasCover_ShouldDeleteBookAndCover() {
         String coverFileName = "cover.jpg";
         Book book = new Book(id, title, author, coverFileName, status, createdAt, Collections.emptySet());
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        useCase.execute(id);
+        useCase.execute(id, userId);
 
-        verify(bookRepository).deleteById(id);
+        verify(bookRepository).findByIdAndUserId(id, userId);
         verify(bookCoverStorage).delete(coverFileName);
     }
 
     @Test
     void execute_WhenBookHasNotCover_ShouldDeleteOnlyBook() {
         Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        useCase.execute(id);
+        useCase.execute(id, userId);
 
-        verify(bookRepository).deleteById(id);
+        verify(bookRepository).findByIdAndUserId(id, userId);
         verifyNoInteractions(bookCoverStorage);
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
@@ -30,6 +30,7 @@ class DeleteCoverUseCaseImplTest {
     private DeleteCoverUseCaseImpl useCase;
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.WANT_TO_READ;
@@ -37,9 +38,9 @@ class DeleteCoverUseCaseImplTest {
 
     @Test
     void execute_WhenBookDoesNotExists_ShouldThrowNotFoundException() {
-        when(bookRepository.findById(id)).thenReturn(Optional.empty());
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(id));
+        assertThrows(NotFoundException.class, () -> useCase.execute(id, userId));
 
         verifyNoInteractions(bookCoverStorage);
     }
@@ -48,23 +49,23 @@ class DeleteCoverUseCaseImplTest {
     void execute_WhenCoverExists_ShouldDeleteFromStorageAndSaveBookWithNullCover() {
         String coverFileName = "cover.jpg";
         Book book = new Book(id, title, author, coverFileName, status, createdAt, Collections.emptySet());
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        useCase.execute(id);
+        useCase.execute(id, userId);
 
         Book updatedBook = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
         verify(bookCoverStorage).delete(coverFileName);
-        verify(bookRepository).save(updatedBook);
+        verify(bookRepository).save(updatedBook, userId);
     }
 
     @Test
     void execute_WhenCoverDoesNotExists_ShouldExitWithoutUpdate() {
         Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        useCase.execute(id);
+        useCase.execute(id, userId);
 
         verify(bookCoverStorage, never()).delete(any());
-        verify(bookRepository, never()).save(any());
+        verify(bookRepository, never()).save(any(), eq(userId));
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
@@ -28,6 +28,8 @@ class GetBookByIdUseCaseImplTest {
     @InjectMocks
     private GetBookByIdUseCaseImpl useCase;
 
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+
     @Test
     void execute_WhenBookExists_ShouldReturnBook() {
         UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
@@ -39,19 +41,19 @@ class GetBookByIdUseCaseImplTest {
         Genre genre2 = new Genre(2, "adventure");
         Set<Genre> genres = Set.of(genre1, genre2);
         Book book = new Book(id, title, author, null, status, createdAt, genres);
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        Book result = useCase.execute(id);
+        Book result = useCase.execute(id, userId);
 
         assertEquals(book, result);
-        verify(bookRepository).findById(id);
+        verify(bookRepository).findByIdAndUserId(id, userId);
     }
 
     @Test
     void execute_WhenBookDoesNotExists_ShouldThrowNotFoundException() {
         UUID id = UUID.fromString("12345678-1234-1234-1234-123456789012");
-        when(bookRepository.findById(id)).thenReturn(Optional.empty());
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(id));
+        assertThrows(NotFoundException.class, () -> useCase.execute(id, userId));
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
@@ -33,6 +33,7 @@ class GetBookCoverUseCaseImplTest {
     private GetBookCoverUseCaseImpl useCase;
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.READING;
@@ -49,32 +50,32 @@ class GetBookCoverUseCaseImplTest {
             content.length
         );
         Book book = new Book(id, title, author, coverFileName, status, createdAt, Collections.emptySet());
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(bookCoverStorage.download(coverFileName)).thenReturn(imageFile);
 
-        ImageFile result = useCase.execute(id);
+        ImageFile result = useCase.execute(id, userId);
 
         assertEquals(imageFile, result);
-        verify(bookRepository).findById(id);
+        verify(bookRepository).findByIdAndUserId(id, userId);
         verify(bookCoverStorage).download(coverFileName);
     }
 
     @Test
     void execute_WhenBookDoesNotExists_ShouldThrowNotFoundException() {
         UUID id = UUID.fromString("12345678-1234-1234-1234-123456789012");
-        when(bookRepository.findById(id)).thenReturn(Optional.empty());
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(id));
+        assertThrows(NotFoundException.class, () -> useCase.execute(id, userId));
     }
 
     @Test
     void execute_WhenCoverDoesNotExists_ShouldThrowNotFoundException() {
         Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(id));
+        assertThrows(NotFoundException.class, () -> useCase.execute(id, userId));
 
-        verify(bookRepository).findById(id);
+        verify(bookRepository).findByIdAndUserId(id, userId);
         verify(bookCoverStorage, never()).download(any());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +38,7 @@ class UpdateBookDetailsUseCaseImplTest {
     private UpdateBookDetailsUseCaseImpl useCase;
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.WANT_TO_READ;
@@ -47,10 +49,10 @@ class UpdateBookDetailsUseCaseImplTest {
     void execute_WhenGenreNotFound_ShouldThrowException() {
         Set<Integer> genreIds = Set.of(1, 5555);
         BookDetailsUpdate data = new BookDetailsUpdate(null, null, null, genreIds);
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(genreRepository.findAllById(genreIds)).thenReturn(Set.of(new Genre(1, "action")));
 
-        String message = assertThrows(NotFoundException.class, () -> useCase.execute(id, data)).getMessage();
+        String message = assertThrows(NotFoundException.class, () -> useCase.execute(id, userId, data)).getMessage();
 
         assertThat(message).contains("5555");
     }
@@ -59,16 +61,16 @@ class UpdateBookDetailsUseCaseImplTest {
     void execute_ShouldUpdateOnlyProvidedFields() {
         Genre genre = new Genre(1, "action");
         BookDetailsUpdate data = new BookDetailsUpdate(" new title ", null, null, Set.of(1));
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(genreRepository.findAllById(Set.of(1))).thenReturn(Set.of(genre));
-        when(bookRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        when(bookRepository.save(any(), eq(userId))).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
-        Book updatedBook = useCase.execute(id, data);
+        Book updatedBook = useCase.execute(id, userId, data);
 
         assertEquals("new title", updatedBook.title());
         assertEquals(author, updatedBook.author());
         assertEquals(status, updatedBook.status());
         assertThat(updatedBook.genres()).containsExactly(genre);
-        verify(bookRepository).save(any());
+        verify(bookRepository).save(any(), eq(userId));
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
@@ -43,6 +43,7 @@ class UploadCoverUseCaseImplTest {
     private final InputStream content = InputStream.nullInputStream();
     private final long contentSize = 0L;
 
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.WANT_TO_READ;
@@ -52,9 +53,9 @@ class UploadCoverUseCaseImplTest {
     @Test
     void execute_WhenBookDoesNotExists_ShouldThrowNotFoundException() {
         UploadCover data = new UploadCover("image/jpeg", content, contentSize);
-        when(bookRepository.findById(id)).thenReturn(Optional.empty());
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> useCase.execute(id, data));
+        assertThrows(NotFoundException.class, () -> useCase.execute(id, userId, data));
 
         verifyNoInteractions(bookCoverStorage);
     }
@@ -62,9 +63,9 @@ class UploadCoverUseCaseImplTest {
     @Test
     void execute_WhenContentTypeIsNotAllowed_ShouldThrowValidationException() {
         UploadCover data = new UploadCover("application/json", content, contentSize);
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
-        assertThrows(ValidationException.class, () -> useCase.execute(id, data));
+        assertThrows(ValidationException.class, () -> useCase.execute(id, userId, data));
 
         verifyNoInteractions(bookCoverStorage);
     }
@@ -75,24 +76,24 @@ class UploadCoverUseCaseImplTest {
         ProcessedImage processedImage = new ProcessedImage("image/jpeg", "jpg", content, contentSize);
         String coverFileName = id + ".jpg";
         ImageFile imageFile = new ImageFile(coverFileName, "image/jpeg", content, contentSize);
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(imageProcessor.process(content)).thenReturn(processedImage);
-        when(bookRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        when(bookRepository.save(any(), eq(userId))).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
-        Book result = useCase.execute(id, data);
+        Book result = useCase.execute(id, userId, data);
 
         assertNotNull(result);
         assertEquals(id, result.id());
         assertEquals(coverFileName, result.coverFileName());
 
         ArgumentCaptor<Book> bookArgumentCaptor = ArgumentCaptor.forClass(Book.class);
-        verify(bookRepository).save(bookArgumentCaptor.capture());
+        verify(bookRepository).save(bookArgumentCaptor.capture(), eq(userId));
 
         Book capturedBook = bookArgumentCaptor.getValue();
         assertEquals(coverFileName, capturedBook.coverFileName());
 
         verify(bookCoverStorage).save(imageFile);
-        verify(bookRepository).save(any());
+        verify(bookRepository).save(any(), eq(userId));
         verify(bookCoverStorage, never()).delete(any());
     }
 
@@ -104,11 +105,11 @@ class UploadCoverUseCaseImplTest {
         ProcessedImage processedImage = new ProcessedImage("image/jpeg", "jpg", content, contentSize);
         UploadCover data = new UploadCover("image/jpeg", content, contentSize);
 
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(imageProcessor.process(content)).thenReturn(processedImage);
-        when(bookRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        when(bookRepository.save(any(), eq(userId))).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
-        Book result = useCase.execute(id, data);
+        Book result = useCase.execute(id, userId, data);
 
         assertEquals(newCoverFileName, result.coverFileName());
         verify(bookCoverStorage).delete(oldCoverFileName);
@@ -121,13 +122,13 @@ class UploadCoverUseCaseImplTest {
         ProcessedImage processedImage = new ProcessedImage("image/jpeg", "jpg", content, contentSize);
         UploadCover data = new UploadCover("image/jpeg", content, contentSize);
 
-        when(bookRepository.findById(id)).thenReturn(Optional.of(book));
+        when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(imageProcessor.process(content)).thenReturn(processedImage);
-        when(bookRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        when(bookRepository.save(any(), eq(userId))).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         doThrow(new RuntimeException("Error")).when(bookCoverStorage).delete(oldCoverFileName);
 
-        assertDoesNotThrow(() -> useCase.execute(id, data));
+        assertDoesNotThrow(() -> useCase.execute(id, userId, data));
 
-        verify(bookRepository).save(any());
+        verify(bookRepository).save(any(), eq(userId));
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
@@ -35,6 +35,8 @@ class BookRepositoryImplTest {
     @Autowired
     private JpaGenreRepository jpaGenreRepository;
 
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+
     @Test
     void findAll_ShouldReturnAllBooks() {
         GenreEntity genre1 = new GenreEntity();
@@ -49,7 +51,7 @@ class BookRepositoryImplTest {
         book1.setStatus(BookStatus.READING);
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(new HashSet<>(genres));
-        book1.setUserId(UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e")); // TODO: REMOVE THIS
+        book1.setUserId(userId); // TODO: REMOVE THIS
 
         BookEntity book2 = new BookEntity();
         book2.setTitle("asd");
@@ -57,7 +59,7 @@ class BookRepositoryImplTest {
         book2.setStatus(BookStatus.WANT_TO_READ);
         book2.setCreatedAt(Instant.ofEpochMilli(177124961234L));
         book2.setGenres(Collections.emptySet());
-        book2.setUserId(UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e")); // TODO: REMOVE THIS
+        book2.setUserId(userId); // TODO: REMOVE THIS
 
         List<BookEntity> entities = jpaBookRepository.saveAll(List.of(book1, book2));
         UUID id1 = entities.get(0).getId();
@@ -65,7 +67,7 @@ class BookRepositoryImplTest {
 
         PageQuery query = new PageQuery(0, 10, "createdAt", SortDirection.DESC);
 
-        PageResult<Book> result = bookRepository.findAll(query);
+        PageResult<Book> result = bookRepository.findAllByUserId(query, userId);
 
         assertEquals(2, result.content().size());
         assertEquals(10, result.size());
@@ -87,11 +89,12 @@ class BookRepositoryImplTest {
         book1.setStatus(BookStatus.READING);
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(Set.of(savedGenre));
+        book1.setUserId(userId);
 
         BookEntity savedBook = jpaBookRepository.save(book1);
         UUID id = savedBook.getId();
 
-        Optional<Book> result = bookRepository.findById(id);
+        Optional<Book> result = bookRepository.findByIdAndUserId(id, userId);
 
         assertTrue(result.isPresent());
         assertEquals(id, result.get().id());
@@ -122,7 +125,7 @@ class BookRepositoryImplTest {
             genres
         );
 
-        Book createdBook = bookRepository.save(book);
+        Book createdBook = bookRepository.save(book, userId);
 
         assertNotNull(createdBook.id());
         assertEquals(title, createdBook.title());
@@ -154,7 +157,7 @@ class BookRepositoryImplTest {
             Collections.emptySet()
         );
 
-        Book updatedBook = bookRepository.save(book);
+        Book updatedBook = bookRepository.save(book, userId);
 
         assertEquals(id, updatedBook.id());
         assertEquals("new_cover.jpg", updatedBook.coverFileName());
@@ -188,7 +191,7 @@ class BookRepositoryImplTest {
             genres
         );
 
-        Book createdBook = bookRepository.save(book);
+        Book createdBook = bookRepository.save(book, userId);
 
         assertNotNull(createdBook.id());
         assertEquals(title, createdBook.title());
@@ -196,7 +199,7 @@ class BookRepositoryImplTest {
         assertEquals(2, createdBook.genres().size());
         assertTrue(jpaBookRepository.existsById(createdBook.id()));
 
-        bookRepository.deleteById(createdBook.id());
+        bookRepository.deleteByIdAndUserId(createdBook.id(), userId);
 
         assertEquals(Optional.empty(), jpaBookRepository.findById(createdBook.id()));
     }

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
@@ -49,6 +49,7 @@ class BookRepositoryImplTest {
         book1.setStatus(BookStatus.READING);
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(new HashSet<>(genres));
+        book1.setUserId(UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e")); // TODO: REMOVE THIS
 
         BookEntity book2 = new BookEntity();
         book2.setTitle("asd");
@@ -56,6 +57,7 @@ class BookRepositoryImplTest {
         book2.setStatus(BookStatus.WANT_TO_READ);
         book2.setCreatedAt(Instant.ofEpochMilli(177124961234L));
         book2.setGenres(Collections.emptySet());
+        book2.setUserId(UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e")); // TODO: REMOVE THIS
 
         List<BookEntity> entities = jpaBookRepository.saveAll(List.of(book1, book2));
         UUID id1 = entities.get(0).getId();

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,6 +85,7 @@ class BookControllerTest {
     private UploadCoverWebMapper uploadCoverWebMapper;
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.READING;
@@ -95,7 +97,7 @@ class BookControllerTest {
         BookResponse bookResponse =
             new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
         PageResult<Book> pageResult = new PageResult<>(List.of(book), 10, 0, 1, 1);
-        when(getBooksUseCase.execute(any(PageQuery.class))).thenReturn(pageResult);
+        when(getBooksUseCase.execute(any(PageQuery.class), eq(userId))).thenReturn(pageResult);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
         var response = mockMvcTester.get().uri("/api/v1/books?page=0&size=10").exchange();
@@ -111,13 +113,13 @@ class BookControllerTest {
             .bodyJson()
             .extractingPath("$.page.totalElements").isEqualTo(1);
 
-        verify(getBooksUseCase).execute(any(PageQuery.class));
+        verify(getBooksUseCase).execute(any(PageQuery.class), eq(userId));
     }
 
     @Test
     void getById_WhenExceptionThrown_ShouldReturnNotFound() {
         UUID id = UUID.fromString("31d3f5e3-7faf-4678-a3cf-4657d8875a82");
-        when(getBookByIdUseCase.execute(id)).thenThrow(BookExceptionFactory.bookNotFound(id));
+        when(getBookByIdUseCase.execute(id, userId)).thenThrow(BookExceptionFactory.bookNotFound(id));
 
         assertThat(mockMvcTester.get().uri("/api/v1/books/" + id))
             .hasStatus(HttpStatus.NOT_FOUND)
@@ -125,7 +127,7 @@ class BookControllerTest {
             .extractingPath("$.detail")
             .isEqualTo("Book with id " + id + " was not found");
 
-        verify(getBookByIdUseCase).execute(id);
+        verify(getBookByIdUseCase).execute(id, userId);
     }
 
     @Test
@@ -133,7 +135,7 @@ class BookControllerTest {
         var response = mockMvcTester.delete().uri("/api/v1/books/" + id);
 
         assertThat(response).hasStatus(HttpStatus.NO_CONTENT);
-        verify(deleteBookUseCase).execute(id);
+        verify(deleteBookUseCase).execute(id, userId);
     }
 
     @Test
@@ -149,7 +151,7 @@ class BookControllerTest {
         BookResponse bookResponse =
             new BookResponse(id, "new title", author, null, "reading", createdAt, Collections.emptySet());
         when(bookWebMapper.toDomain(request)).thenReturn(data);
-        when(updateBookDetailsUseCase.execute(id, data)).thenReturn(book);
+        when(updateBookDetailsUseCase.execute(id, userId, data)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
         assertThat(
@@ -175,7 +177,7 @@ class BookControllerTest {
         BookResponse bookResponse =
             new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
         when(bookWebMapper.toDomain(request)).thenReturn(data);
-        when(createBookUseCase.execute(data)).thenReturn(book);
+        when(createBookUseCase.execute(data, userId)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
         assertThat(
@@ -208,7 +210,7 @@ class BookControllerTest {
         BookResponse bookResponse =
             new BookResponse(id, title, author, coverFileName, status.getValue(), createdAt, null);
         when(uploadCoverWebMapper.toDomain(mockMultipartFile)).thenReturn(data);
-        when(uploadCoverUseCase.execute(id, data)).thenReturn(book);
+        when(uploadCoverUseCase.execute(id, userId, data)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
         assertThat(
@@ -227,7 +229,7 @@ class BookControllerTest {
         var response = mockMvcTester.delete().uri("/api/v1/books/" + id + "/cover");
 
         assertThat(response).hasStatus(HttpStatus.NO_CONTENT);
-        verify(deleteCoverUseCase).execute(id);
+        verify(deleteCoverUseCase).execute(id, userId);
     }
 
     @Test
@@ -241,7 +243,7 @@ class BookControllerTest {
             new ByteArrayInputStream(content),
             content.length
         );
-        when(getBookCoverUseCase.execute(id)).thenReturn(imageFile);
+        when(getBookCoverUseCase.execute(id, userId)).thenReturn(imageFile);
 
         assertThat(mockMvcTester.get().uri("/api/v1/books/" + id + "/cover"))
             .hasStatus(HttpStatus.OK)

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -7,3 +7,13 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/04__book_genres-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/05__rename-cover_url-field.yaml
+  - include:
+      file: classpath:/db/changelog/changes/06__users-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/07__add-archive-user-to-users.yaml
+  - include:
+      file: classpath:/db/changelog/changes/08__add-nullable-user_id-field-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/09__set-archive-user-id-to-all-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/10__set-user_id-not-null-in-books.yaml


### PR DESCRIPTION
### What does this PR do?

- Added database migrations to add the `users` table and link `books` via `user_id`.
- Migrated existing database records to a new archive user.
- Updated the `BookRepository` and use cases to accept `userId`.
- Implemented temporary `userId` hardcoding in the `BookController` until the authentication system is configured.

Tests:
- Updated tests to include the new `userId` parameter.

### Related tickets

Closes #70

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

All books created in last versions have been migrated to a public archive account. 
- Email: `archive@example.com`
- Password: `archive`
