### PR TITLE
feat: add user models and repository

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -7,4 +7,5 @@ public class Tables {
     public final String GENRES = "genres";
     public final String BOOKS = "books";
     public final String BOOK_GENRES = "book_genres";
+    public final String USERS = "users";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/UserEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/UserEntity.java
@@ -1,0 +1,34 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.UserRules;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = Tables.USERS)
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserEntity {
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "email", length = UserRules.EMAIL_MAX_LENGTH, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", length = UserRules.PASSWORD_HASH_MAX_LENGTH, nullable = false)
+    private String passwordHash;
+
+    @Column(name = "is_verified", nullable = false)
+    private boolean isVerified;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaUserRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaUserRepository.java
@@ -1,0 +1,12 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface JpaUserRepository extends JpaRepository<UserEntity, UUID> {
+    Optional<UserEntity> findByEmail(String email);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/UserDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/UserDataMapper.java
@@ -1,0 +1,32 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+
+@Component
+public class UserDataMapper {
+    public User toDomain(UserEntity entity) {
+        if (entity == null) return null;
+
+        return new User(
+            entity.getId(),
+            entity.getEmail(),
+            entity.getPasswordHash(),
+            entity.isVerified(),
+            entity.getCreatedAt()
+        );
+    }
+
+    public UserEntity toEntity(User user) {
+        if (user == null) return null;
+
+        UserEntity entity = new UserEntity();
+        entity.setId(user.id());
+        entity.setEmail(user.email());
+        entity.setPasswordHash(user.passwordHash());
+        entity.setVerified(user.isVerified());
+        entity.setCreatedAt(user.createdAt());
+        return entity;
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/UserRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/UserRepositoryImpl.java
@@ -1,0 +1,35 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
+import ru.jerael.booktracker.backend.data.mapper.UserDataMapper;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+    private final JpaUserRepository jpaUserRepository;
+    private final UserDataMapper userDataMapper;
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return jpaUserRepository.findById(id).map(userDataMapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return jpaUserRepository.findByEmail(email).map(userDataMapper::toDomain);
+    }
+
+    @Override
+    public User save(User user) {
+        UserEntity entity = userDataMapper.toEntity(user);
+        UserEntity savedEntity = jpaUserRepository.save(entity);
+        return userDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/UserRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/UserRules.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class UserRules {
+    private UserRules() {}
+
+    public static final int EMAIL_MAX_LENGTH = 255;
+    public static final int PASSWORD_HASH_MAX_LENGTH = 255;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/user/User.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/user/User.java
@@ -1,0 +1,12 @@
+package ru.jerael.booktracker.backend.domain.model.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record User(
+    UUID id,
+    String email,
+    String passwordHash,
+    boolean isVerified,
+    Instant createdAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/user/UserCreation.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/user/UserCreation.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.domain.model.user;
+
+public record UserCreation(
+    String email,
+    String password
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/UserRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+    Optional<User> findById(UUID id);
+
+    Optional<User> findByEmail(String email);
+
+    User save(User user);
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/UserDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/UserDataMapperTest.java
@@ -1,0 +1,49 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.Assert.assertEquals;
+
+class UserDataMapperTest {
+    private final UserDataMapper userDataMapper = new UserDataMapper();
+
+    private final UUID id = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String email = "test@example.com";
+    private final String passwordHash = "password hash";
+    private final boolean isVerified = true;
+    private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    @Test
+    void toDomain() {
+        UserEntity entity = new UserEntity();
+        entity.setId(id);
+        entity.setEmail(email);
+        entity.setPasswordHash(passwordHash);
+        entity.setVerified(isVerified);
+        entity.setCreatedAt(createdAt);
+
+        User user = userDataMapper.toDomain(entity);
+
+        assertEquals(id, user.id());
+        assertEquals(email, user.email());
+        assertEquals(passwordHash, user.passwordHash());
+        assertEquals(isVerified, user.isVerified());
+        assertEquals(createdAt, user.createdAt());
+    }
+
+    @Test
+    void toEntity() {
+        User user = new User(id, email, passwordHash, isVerified, createdAt);
+
+        UserEntity entity = userDataMapper.toEntity(user);
+
+        assertEquals(id, entity.getId());
+        assertEquals(email, entity.getEmail());
+        assertEquals(passwordHash, entity.getPasswordHash());
+        assertEquals(isVerified, entity.isVerified());
+        assertEquals(createdAt, entity.getCreatedAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImplTest.java
@@ -26,7 +26,7 @@ class GenreRepositoryImplTest {
     private JpaGenreRepository jpaGenreRepository;
 
     @Test
-    void getGenres_ShouldReturnAllGenres() {
+    void getGenres_ShouldReturnAllGenres() { // TODO: rename
         GenreEntity entity1 = new GenreEntity();
         entity1.setName("adventure");
         GenreEntity entity2 = new GenreEntity();
@@ -40,7 +40,7 @@ class GenreRepositoryImplTest {
     }
 
     @Test
-    void getGenreById_WhenExists_ShouldReturnGenre() {
+    void getGenreById_WhenExists_ShouldReturnGenre() { // TODO: rename
         GenreEntity entity = new GenreEntity();
         entity.setName("adventure");
         GenreEntity savedEntity = jpaGenreRepository.save(entity);

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/UserRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/UserRepositoryImplTest.java
@@ -1,0 +1,107 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
+import ru.jerael.booktracker.backend.data.mapper.UserDataMapper;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({UserRepositoryImpl.class, UserDataMapper.class})
+class UserRepositoryImplTest {
+
+    @Autowired
+    private UserRepositoryImpl userRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    private final String email = "test@example.com";
+    private final String passwordHash = "password hash";
+    private final boolean isVerified = true;
+    private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    @Test
+    void findById_WhenExists_ShouldReturnUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail(email);
+        entity.setPasswordHash(passwordHash);
+        entity.setVerified(isVerified);
+        entity.setCreatedAt(createdAt);
+        UserEntity savedUser = jpaUserRepository.save(entity);
+        UUID userId = savedUser.getId();
+
+        Optional<User> result = userRepository.findById(userId);
+
+        assertTrue(result.isPresent());
+        assertEquals(userId, result.get().id());
+        assertEquals(email, result.get().email());
+    }
+
+    @Test
+    void findByEmail_WhenExists_ShouldReturnUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail(email);
+        entity.setPasswordHash(passwordHash);
+        entity.setVerified(isVerified);
+        entity.setCreatedAt(createdAt);
+
+        UserEntity savedUser = jpaUserRepository.save(entity);
+        UUID userId = savedUser.getId();
+
+        Optional<User> result = userRepository.findByEmail(email);
+
+        assertTrue(result.isPresent());
+        assertEquals(userId, result.get().id());
+        assertEquals(email, result.get().email());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewUser() {
+        User user = new User(null, email, passwordHash, isVerified, createdAt);
+
+        User savedUser = userRepository.save(user);
+
+        assertNotNull(savedUser.id());
+        assertEquals(email, savedUser.email());
+        assertEquals(passwordHash, savedUser.passwordHash());
+        assertEquals(isVerified, savedUser.isVerified());
+        assertEquals(createdAt, savedUser.createdAt());
+        assertTrue(jpaUserRepository.existsById(savedUser.id()));
+    }
+
+    @Test
+    void save_WhenIdIsPresent_ShouldUpdateExistingUser() {
+        UserEntity userEntity = new UserEntity();
+        userEntity.setEmail(email);
+        userEntity.setPasswordHash(passwordHash);
+        userEntity.setVerified(false);
+        userEntity.setCreatedAt(createdAt);
+
+        UserEntity savedUser = jpaUserRepository.save(userEntity);
+        UUID userId = savedUser.getId();
+
+        User user = new User(
+            userId,
+            "new email",
+            "new password hash",
+            true,
+            savedUser.getCreatedAt()
+        );
+
+        User updatedUser = userRepository.save(user);
+
+        assertEquals(userId, updatedUser.id());
+        assertEquals("new email", updatedUser.email());
+        assertEquals("new password hash", updatedUser.passwordHash());
+        assertTrue(updatedUser.isVerified());
+        assertEquals(createdAt, updatedUser.createdAt());
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Added `User` and `UserCreation` Domain models.
- Added `UserEntity` and `UserRepository` implementation.
- Implemented `JpaUserRepository`.
- Added `UserDataMapper` for mapping `UserEntity` <-> `User`.
- Added `UserRules` for containing business rules for `UserEntity` (`email` max length, `passwordHash` max length).

Tests:
- Added tests for `UserRepositoryImpl` and `UserDataMapper`.

### Related tickets

Part of #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
