### PR TITLE
feat: add email verification lifecycle

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImpl.java
@@ -1,0 +1,66 @@
+package ru.jerael.booktracker.backend.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.jerael.booktracker.backend.application.validator.VerificationTokenValidatorImpl;
+import ru.jerael.booktracker.backend.domain.exception.factory.EmailVerificationExceptionFactory;
+import ru.jerael.booktracker.backend.domain.mail.VerificationMailMessage;
+import ru.jerael.booktracker.backend.domain.model.verification.*;
+import ru.jerael.booktracker.backend.domain.repository.EmailVerificationRepository;
+import ru.jerael.booktracker.backend.domain.smtp.SmtpService;
+import ru.jerael.booktracker.backend.domain.verification.EmailVerificationService;
+import ru.jerael.booktracker.backend.domain.verification.VerificationCodeGenerator;
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationServiceImpl implements EmailVerificationService {
+    private final VerificationCodeGenerator verificationCodeGenerator;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final SmtpService smtpService;
+    private final VerificationTokenValidatorImpl verificationTokenValidator;
+
+    @Override
+    @Transactional
+    public void initiate(EmailVerificationInitiation payload) {
+        UUID userId = payload.userId();
+        String email = payload.email();
+        VerificationType type = payload.type();
+
+        emailVerificationRepository.deleteByUserIdAndType(userId, type);
+
+        VerificationCode code = verificationCodeGenerator.generate();
+
+        EmailVerification emailVerification = new EmailVerification(
+            null,
+            userId,
+            email,
+            type,
+            code.value(),
+            Instant.now().plusMillis(code.expiry().toMillis()),
+            Instant.now()
+        );
+        emailVerificationRepository.save(emailVerification);
+
+        smtpService.sendEmail(email, new VerificationMailMessage(code));
+    }
+
+    @Override
+    @Transactional
+    public EmailVerification confirm(EmailVerificationConfirmation payload) {
+        UUID userId = payload.userId();
+        String token = payload.token();
+        VerificationType type = payload.type();
+
+        EmailVerification emailVerification = emailVerificationRepository.findByUserIdAndType(userId, type)
+            .orElseThrow(() -> EmailVerificationExceptionFactory.verificationNotFound(userId, type));
+
+        verificationTokenValidator.validate(emailVerification, token);
+
+        emailVerificationRepository.deleteByUserIdAndType(userId, type);
+
+        return emailVerification;
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImpl.java
@@ -10,14 +10,14 @@ import ru.jerael.booktracker.backend.domain.model.verification.*;
 import ru.jerael.booktracker.backend.domain.repository.EmailVerificationRepository;
 import ru.jerael.booktracker.backend.domain.smtp.SmtpService;
 import ru.jerael.booktracker.backend.domain.verification.EmailVerificationService;
-import ru.jerael.booktracker.backend.domain.verification.VerificationCodeGenerator;
+import ru.jerael.booktracker.backend.domain.verification.VerificationTokenGenerator;
 import java.time.Instant;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationServiceImpl implements EmailVerificationService {
-    private final VerificationCodeGenerator verificationCodeGenerator;
+    private final VerificationTokenGenerator verificationTokenGenerator;
     private final EmailVerificationRepository emailVerificationRepository;
     private final SmtpService smtpService;
     private final VerificationTokenValidatorImpl verificationTokenValidator;
@@ -31,20 +31,20 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
         emailVerificationRepository.deleteByUserIdAndType(userId, type);
 
-        VerificationCode code = verificationCodeGenerator.generate();
+        VerificationToken token = verificationTokenGenerator.generate();
 
         EmailVerification emailVerification = new EmailVerification(
             null,
             userId,
             email,
             type,
-            code.value(),
-            Instant.now().plusMillis(code.expiry().toMillis()),
+            token.value(),
+            Instant.now().plusMillis(token.expiry().toMillis()),
             Instant.now()
         );
         emailVerificationRepository.save(emailVerification);
 
-        smtpService.sendEmail(email, new VerificationMailMessage(code));
+        smtpService.sendEmail(email, new VerificationMailMessage(token));
     }
 
     @Override

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/VerificationTokenValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/VerificationTokenValidatorImpl.java
@@ -1,0 +1,27 @@
+package ru.jerael.booktracker.backend.application.validator;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.exception.factory.EmailVerificationErrorFactory;
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.validator.VerificationTokenValidator;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class VerificationTokenValidatorImpl implements VerificationTokenValidator {
+    public void validate(EmailVerification emailVerification, String token) {
+        List<ValidationError> errors = new ArrayList<>();
+        if (Instant.now().isAfter(emailVerification.expiresAt())) {
+            errors.add(EmailVerificationErrorFactory.tokenExpired());
+        }
+        if (!emailVerification.token().equals(token)) {
+            errors.add(EmailVerificationErrorFactory.invalidToken());
+        }
+        if (!errors.isEmpty()) {
+            throw new ValidationException(errors);
+        }
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -8,4 +8,5 @@ public class Tables {
     public final String BOOKS = "books";
     public final String BOOK_GENRES = "book_genres";
     public final String USERS = "users";
+    public final String EMAIL_VERIFICATIONS = "email_verifications";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/EmailVerificationEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/EmailVerificationEntity.java
@@ -1,0 +1,43 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.UserRules;
+import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.time.Instant;
+import java.util.UUID;
+
+@Table(name = Tables.EMAIL_VERIFICATIONS)
+@Setter
+@Getter
+@Entity
+@NoArgsConstructor
+public class EmailVerificationEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "email", length = UserRules.EMAIL_MAX_LENGTH, nullable = false)
+    private String email;
+
+    @Column(name = "verification_type", length = EmailVerificationRules.TYPE_MAX_LENGTH, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private VerificationType type;
+
+    @Column(name = "token", length = EmailVerificationRules.TOKEN_MAX_LENGTH, nullable = false)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaEmailVerificationRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaEmailVerificationRepository.java
@@ -1,0 +1,15 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.EmailVerificationEntity;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface JpaEmailVerificationRepository extends JpaRepository<EmailVerificationEntity, UUID> {
+    void deleteByUserIdAndType(UUID userId, VerificationType type);
+
+    Optional<EmailVerificationEntity> findByUserIdAndType(UUID userId, VerificationType type);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/EmailVerificationDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/EmailVerificationDataMapper.java
@@ -1,0 +1,36 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.EmailVerificationEntity;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+
+@Component
+public class EmailVerificationDataMapper {
+    public EmailVerification toDomain(EmailVerificationEntity entity) {
+        if (entity == null) return null;
+
+        return new EmailVerification(
+            entity.getId(),
+            entity.getUserId(),
+            entity.getEmail(),
+            entity.getType(),
+            entity.getToken(),
+            entity.getExpiresAt(),
+            entity.getCreatedAt()
+        );
+    }
+
+    public EmailVerificationEntity toEntity(EmailVerification emailVerification) {
+        if (emailVerification == null) return null;
+
+        EmailVerificationEntity entity = new EmailVerificationEntity();
+        entity.setId(emailVerification.id());
+        entity.setUserId(emailVerification.userId());
+        entity.setEmail(emailVerification.email());
+        entity.setType(emailVerification.type());
+        entity.setToken(emailVerification.token());
+        entity.setExpiresAt(emailVerification.expiresAt());
+        entity.setCreatedAt(emailVerification.createdAt());
+        return entity;
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/EmailVerificationRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/EmailVerificationRepositoryImpl.java
@@ -1,0 +1,37 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.EmailVerificationEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaEmailVerificationRepository;
+import ru.jerael.booktracker.backend.data.mapper.EmailVerificationDataMapper;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import ru.jerael.booktracker.backend.domain.repository.EmailVerificationRepository;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationRepositoryImpl implements EmailVerificationRepository {
+    private final JpaEmailVerificationRepository jpaEmailVerificationRepository;
+    private final EmailVerificationDataMapper emailVerificationDataMapper;
+
+    @Override
+    public void deleteByUserIdAndType(UUID userId, VerificationType type) {
+        jpaEmailVerificationRepository.deleteByUserIdAndType(userId, type);
+    }
+
+    @Override
+    public Optional<EmailVerification> findByUserIdAndType(UUID userId, VerificationType type) {
+        return jpaEmailVerificationRepository.findByUserIdAndType(userId, type)
+            .map(emailVerificationDataMapper::toDomain);
+    }
+
+    @Override
+    public EmailVerification save(EmailVerification emailVerification) {
+        EmailVerificationEntity entity = emailVerificationDataMapper.toEntity(emailVerification);
+        EmailVerificationEntity savedEntity = jpaEmailVerificationRepository.save(entity);
+        return emailVerificationDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/verification/OtpCodeGenerator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/verification/OtpCodeGenerator.java
@@ -3,24 +3,24 @@ package ru.jerael.booktracker.backend.data.verification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ru.jerael.booktracker.backend.data.verification.config.OtpCodeProperties;
-import ru.jerael.booktracker.backend.domain.model.verification.VerificationCode;
-import ru.jerael.booktracker.backend.domain.verification.VerificationCodeGenerator;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationToken;
+import ru.jerael.booktracker.backend.domain.verification.VerificationTokenGenerator;
 import java.security.SecureRandom;
 
 @Service
 @RequiredArgsConstructor
-public class OtpCodeGenerator implements VerificationCodeGenerator {
+public class OtpCodeGenerator implements VerificationTokenGenerator {
     private final OtpCodeProperties properties;
     private final SecureRandom secureRandom = new SecureRandom();
 
     @Override
-    public VerificationCode generate() {
+    public VerificationToken generate() {
         StringBuilder code = new StringBuilder(properties.getLength());
         for (int i = 0; i < properties.getLength(); i++) {
             int digit = secureRandom.nextInt(10);
             code.append(digit);
         }
-        return new VerificationCode(
+        return new VerificationToken(
             code.toString(),
             properties.getExpiry()
         );

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/EmailVerificationRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/EmailVerificationRules.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class EmailVerificationRules {
+    private EmailVerificationRules() {}
+
+    public static final int TYPE_MAX_LENGTH = 255;
+    public static final int TOKEN_MAX_LENGTH = 255;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/code/EmailVerificationErrorCode.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/code/EmailVerificationErrorCode.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.exception.code;
+
+public enum EmailVerificationErrorCode implements ErrorCode {
+    VERIFICATION_NOT_FOUND,
+    TOKEN_EXPIRED,
+    INVALID_TOKEN
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/EmailVerificationErrorFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/EmailVerificationErrorFactory.java
@@ -8,8 +8,8 @@ public class EmailVerificationErrorFactory {
     public static ValidationError tokenExpired() {
         return new ValidationError(
             EmailVerificationErrorCode.TOKEN_EXPIRED.name(),
-            "Verification token has expired",
             "token",
+            "Verification token has expired",
             Map.of()
         );
     }
@@ -17,8 +17,8 @@ public class EmailVerificationErrorFactory {
     public static ValidationError invalidToken() {
         return new ValidationError(
             EmailVerificationErrorCode.INVALID_TOKEN.name(),
-            "Verification token is invalid",
             "token",
+            "Verification token is invalid",
             Map.of()
         );
     }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/EmailVerificationErrorFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/EmailVerificationErrorFactory.java
@@ -1,0 +1,25 @@
+package ru.jerael.booktracker.backend.domain.exception.factory;
+
+import ru.jerael.booktracker.backend.domain.exception.code.EmailVerificationErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import java.util.Map;
+
+public class EmailVerificationErrorFactory {
+    public static ValidationError tokenExpired() {
+        return new ValidationError(
+            EmailVerificationErrorCode.TOKEN_EXPIRED.name(),
+            "Verification token has expired",
+            "token",
+            Map.of()
+        );
+    }
+
+    public static ValidationError invalidToken() {
+        return new ValidationError(
+            EmailVerificationErrorCode.INVALID_TOKEN.name(),
+            "Verification token is invalid",
+            "token",
+            Map.of()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/EmailVerificationExceptionFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/EmailVerificationExceptionFactory.java
@@ -1,0 +1,15 @@
+package ru.jerael.booktracker.backend.domain.exception.factory;
+
+import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
+import ru.jerael.booktracker.backend.domain.exception.code.EmailVerificationErrorCode;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.util.UUID;
+
+public class EmailVerificationExceptionFactory {
+    public static NotFoundException verificationNotFound(UUID userId, VerificationType type) {
+        return new NotFoundException(
+            EmailVerificationErrorCode.VERIFICATION_NOT_FOUND,
+            String.format("Verification for user '%s' with request '%s' was not found", userId, type)
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/mail/VerificationMailMessage.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/mail/VerificationMailMessage.java
@@ -1,12 +1,12 @@
 package ru.jerael.booktracker.backend.domain.mail;
 
-import ru.jerael.booktracker.backend.domain.model.verification.VerificationCode;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationToken;
 
 public class VerificationMailMessage implements MailMessage {
-    private final VerificationCode code;
+    private final VerificationToken token;
 
-    public VerificationMailMessage(VerificationCode code) {
-        this.code = code;
+    public VerificationMailMessage(VerificationToken token) {
+        this.token = token;
     }
 
     @Override
@@ -27,8 +27,8 @@ public class VerificationMailMessage implements MailMessage {
                     \s
                     If you did not request this, please ignore this email.
                 \s""",
-            code.value(),
-            code.expiry().toMinutes()
+            token.value(),
+            token.expiry().toMinutes()
         );
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerification.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerification.java
@@ -1,0 +1,14 @@
+package ru.jerael.booktracker.backend.domain.model.verification;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record EmailVerification(
+    UUID id,
+    UUID userId,
+    String email,
+    VerificationType type,
+    String token,
+    Instant expiresAt,
+    Instant createdAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerificationConfirmation.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerificationConfirmation.java
@@ -1,0 +1,9 @@
+package ru.jerael.booktracker.backend.domain.model.verification;
+
+import java.util.UUID;
+
+public record EmailVerificationConfirmation(
+    UUID userId,
+    String token,
+    VerificationType type
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerificationInitiation.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerificationInitiation.java
@@ -2,7 +2,7 @@ package ru.jerael.booktracker.backend.domain.model.verification;
 
 import java.util.UUID;
 
-public record EmailVerificationPayload(
+public record EmailVerificationInitiation(
     UUID userId,
     String email,
     VerificationType type

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerificationPayload.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/EmailVerificationPayload.java
@@ -1,0 +1,9 @@
+package ru.jerael.booktracker.backend.domain.model.verification;
+
+import java.util.UUID;
+
+public record EmailVerificationPayload(
+    UUID userId,
+    String email,
+    VerificationType type
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/VerificationToken.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/VerificationToken.java
@@ -2,7 +2,7 @@ package ru.jerael.booktracker.backend.domain.model.verification;
 
 import java.time.Duration;
 
-public record VerificationCode(
+public record VerificationToken(
     String value,
     Duration expiry
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/VerificationType.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/verification/VerificationType.java
@@ -1,0 +1,5 @@
+package ru.jerael.booktracker.backend.domain.model.verification;
+
+public enum VerificationType {
+    REGISTRATION
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/EmailVerificationRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/EmailVerificationRepository.java
@@ -1,0 +1,14 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface EmailVerificationRepository {
+    void deleteByUserIdAndType(UUID userId, VerificationType type);
+
+    Optional<EmailVerification> findByUserIdAndType(UUID userId, VerificationType type);
+
+    EmailVerification save(EmailVerification emailVerification);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/VerificationTokenValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/VerificationTokenValidator.java
@@ -3,5 +3,5 @@ package ru.jerael.booktracker.backend.domain.validator;
 import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
 
 public interface VerificationTokenValidator {
-    void validate(EmailVerification emailVerification, String code);
+    void validate(EmailVerification emailVerification, String token);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/VerificationTokenValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/VerificationTokenValidator.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.validator;
+
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+
+public interface VerificationTokenValidator {
+    void validate(EmailVerification emailVerification, String code);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/verification/EmailVerificationService.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/verification/EmailVerificationService.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.domain.verification;
+
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationConfirmation;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationInitiation;
+
+public interface EmailVerificationService {
+    void initiate(EmailVerificationInitiation payload);
+
+    EmailVerification confirm(EmailVerificationConfirmation payload);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/verification/VerificationCodeGenerator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/verification/VerificationCodeGenerator.java
@@ -1,7 +1,0 @@
-package ru.jerael.booktracker.backend.domain.verification;
-
-import ru.jerael.booktracker.backend.domain.model.verification.VerificationCode;
-
-public interface VerificationCodeGenerator {
-    VerificationCode generate();
-}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/verification/VerificationTokenGenerator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/verification/VerificationTokenGenerator.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.verification;
+
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationToken;
+
+public interface VerificationTokenGenerator {
+    VerificationToken generate();
+}

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -19,3 +19,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/09__set-archive-user-id-to-all-books.yaml
   - include:
       file: classpath:/db/changelog/changes/10__set-user_id-not-null-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/11__email_verifications-schema.yaml

--- a/src/main/resources/db/changelog/changes/11__email_verifications-schema.yaml
+++ b/src/main/resources/db/changelog/changes/11__email_verifications-schema.yaml
@@ -1,0 +1,77 @@
+databaseChangeLog:
+  - changeSet:
+      id: 11__сreate-email_verifications-table
+      author: Jerael
+      comment: сreate email_verifications table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: email_verifications
+      changes:
+        - createTable:
+            tableName: email_verifications
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: email
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: verification_type
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: token
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: email_verifications
+            columnNames: id
+            constraintName: pk_email_verifications
+        - addForeignKeyConstraint:
+            baseTableName: email_verifications
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: user_id
+            constraintName: fk_email_verifications_user_id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_email_verifications_expires_at
+            using: btree
+            tableName: email_verifications
+            columns:
+              - column:
+                  name: expires_at
+        - createIndex:
+            indexName: idx_email_verifications_user_id_type
+            using: btree
+            tableName: email_verifications
+            columns:
+              - column:
+                  name: user_id
+              - column:
+                  name: verification_type

--- a/src/test/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImplTest.java
@@ -12,7 +12,7 @@ import ru.jerael.booktracker.backend.domain.mail.VerificationMailMessage;
 import ru.jerael.booktracker.backend.domain.model.verification.*;
 import ru.jerael.booktracker.backend.domain.repository.EmailVerificationRepository;
 import ru.jerael.booktracker.backend.domain.smtp.SmtpService;
-import ru.jerael.booktracker.backend.domain.verification.VerificationCodeGenerator;
+import ru.jerael.booktracker.backend.domain.verification.VerificationTokenGenerator;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.*;
 class EmailVerificationServiceImplTest {
 
     @Mock
-    private VerificationCodeGenerator verificationCodeGenerator;
+    private VerificationTokenGenerator verificationTokenGenerator;
 
     @Mock
     private EmailVerificationRepository emailVerificationRepository;
@@ -47,8 +47,8 @@ class EmailVerificationServiceImplTest {
     @Test
     void initiate_ShouldCleanOldCodeAndSaveNewOne() {
         EmailVerificationInitiation payload = new EmailVerificationInitiation(userId, email, type);
-        VerificationCode code = new VerificationCode(token, Duration.ofMinutes(10L));
-        when(verificationCodeGenerator.generate()).thenReturn(code);
+        VerificationToken verificationToken = new VerificationToken(token, Duration.ofMinutes(10L));
+        when(verificationTokenGenerator.generate()).thenReturn(verificationToken);
 
         service.initiate(payload);
 

--- a/src/test/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImplTest.java
@@ -1,0 +1,88 @@
+package ru.jerael.booktracker.backend.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.application.validator.VerificationTokenValidatorImpl;
+import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
+import ru.jerael.booktracker.backend.domain.mail.VerificationMailMessage;
+import ru.jerael.booktracker.backend.domain.model.verification.*;
+import ru.jerael.booktracker.backend.domain.repository.EmailVerificationRepository;
+import ru.jerael.booktracker.backend.domain.smtp.SmtpService;
+import ru.jerael.booktracker.backend.domain.verification.VerificationCodeGenerator;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceImplTest {
+
+    @Mock
+    private VerificationCodeGenerator verificationCodeGenerator;
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private SmtpService smtpService;
+
+    @Mock
+    private VerificationTokenValidatorImpl verificationTokenValidator;
+
+    @InjectMocks
+    private EmailVerificationServiceImpl service;
+
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String email = "test@example.com";
+    private final VerificationType type = VerificationType.REGISTRATION;
+    private final String token = "123456";
+
+    @Test
+    void initiate_ShouldCleanOldCodeAndSaveNewOne() {
+        EmailVerificationInitiation payload = new EmailVerificationInitiation(userId, email, type);
+        VerificationCode code = new VerificationCode(token, Duration.ofMinutes(10L));
+        when(verificationCodeGenerator.generate()).thenReturn(code);
+
+        service.initiate(payload);
+
+        verify(emailVerificationRepository).deleteByUserIdAndType(userId, type);
+        verify(smtpService).sendEmail(eq(email), any(VerificationMailMessage.class));
+
+        ArgumentCaptor<EmailVerification> captor = ArgumentCaptor.forClass(EmailVerification.class);
+        verify(emailVerificationRepository).save(captor.capture());
+
+        EmailVerification savedVerification = captor.getValue();
+        assertEquals(email, savedVerification.email());
+        assertEquals(token, savedVerification.token());
+        assertNotNull(savedVerification.expiresAt());
+    }
+
+    @Test
+    void confirm_ShouldValidateAndDeleteExistingCode() {
+        EmailVerificationConfirmation payload = new EmailVerificationConfirmation(userId, token, type);
+        EmailVerification existing = mock(EmailVerification.class);
+        when(emailVerificationRepository.findByUserIdAndType(userId, type)).thenReturn(Optional.of(existing));
+
+        EmailVerification result = service.confirm(payload);
+
+        assertNotNull(result);
+        verify(verificationTokenValidator).validate(existing, token);
+        verify(emailVerificationRepository).deleteByUserIdAndType(userId, type);
+    }
+
+    @Test
+    void confirm_ShouldThrowNotFoundException_WhenRecordDoesNotExistInDb() {
+        EmailVerificationConfirmation payload = new EmailVerificationConfirmation(userId, token, type);
+        when(emailVerificationRepository.findByUserIdAndType(userId, type)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.confirm(payload));
+        verify(verificationTokenValidator, never()).validate(any(), any());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/VerificationTokenValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/VerificationTokenValidatorImplTest.java
@@ -1,0 +1,59 @@
+package ru.jerael.booktracker.backend.application.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VerificationTokenValidatorImplTest {
+    private final VerificationTokenValidatorImpl validator = new VerificationTokenValidatorImpl();
+
+    private final UUID id = UUID.fromString("d756300f-6a7f-45df-96c7-55977999f7c9");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final VerificationType type = VerificationType.REGISTRATION;
+    private final String token = "token";
+    private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    private EmailVerification createVerification(Instant expiresAt) {
+        return new EmailVerification(id, userId, "test@example.com", type, token, expiresAt, createdAt);
+    }
+
+    @Test
+    void validate_ShouldNotThrowException_WhenTokenIsValid() {
+        EmailVerification verification = createVerification(Instant.now().plusSeconds(60L));
+
+        assertDoesNotThrow(() -> validator.validate(verification, token));
+    }
+
+    @Test
+    void validate_ShouldThrowValidationException_WhenTokenIsExpired() {
+        EmailVerification verification = createVerification(Instant.now().minusSeconds(60L));
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> validator.validate(verification, token));
+
+        assertTrue(ex.getErrors().stream().anyMatch(e -> e.message().contains("expired")));
+    }
+
+    @Test
+    void validate_ShouldThrowValidationException_WhenTokenMismatched() {
+        EmailVerification verification = createVerification(Instant.now().plusSeconds(60L));
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> validator.validate(verification, "invalid token"));
+
+        assertTrue(ex.getErrors().stream().anyMatch(e -> e.message().contains("invalid")));
+    }
+
+    @Test
+    void validate_ShouldAccumulateMultipleErrors_WhenTokenIsExpiredAndMismatched() {
+        EmailVerification verification = createVerification(Instant.now().minusSeconds(60L));
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> validator.validate(verification, "invalid token"));
+
+        assertEquals(2, ex.getErrors().size());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/EmailVerificationDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/EmailVerificationDataMapperTest.java
@@ -1,0 +1,59 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.EmailVerificationEntity;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EmailVerificationDataMapperTest {
+    private final EmailVerificationDataMapper emailVerificationDataMapper = new EmailVerificationDataMapper();
+
+    private final UUID id = UUID.fromString("d756300f-6a7f-45df-96c7-55977999f7c9");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String email = "test@example.com";
+    private final VerificationType type = VerificationType.REGISTRATION;
+    private final String token = "token";
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+    private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    @Test
+    void toDomain() {
+        EmailVerificationEntity entity = new EmailVerificationEntity();
+        entity.setId(id);
+        entity.setUserId(userId);
+        entity.setEmail(email);
+        entity.setType(type);
+        entity.setToken(token);
+        entity.setExpiresAt(expiresAt);
+        entity.setCreatedAt(createdAt);
+
+        EmailVerification emailVerification = emailVerificationDataMapper.toDomain(entity);
+
+        assertEquals(id, emailVerification.id());
+        assertEquals(userId, emailVerification.userId());
+        assertEquals(email, emailVerification.email());
+        assertEquals(type, emailVerification.type());
+        assertEquals(token, emailVerification.token());
+        assertEquals(expiresAt, emailVerification.expiresAt());
+        assertEquals(createdAt, emailVerification.createdAt());
+    }
+
+    @Test
+    void toEntity() {
+        EmailVerification emailVerification =
+            new EmailVerification(id, userId, email, type, token, expiresAt, createdAt);
+
+        EmailVerificationEntity entity = emailVerificationDataMapper.toEntity(emailVerification);
+
+        assertEquals(id, entity.getId());
+        assertEquals(userId, entity.getUserId());
+        assertEquals(email, entity.getEmail());
+        assertEquals(type, entity.getType());
+        assertEquals(token, entity.getToken());
+        assertEquals(expiresAt, entity.getExpiresAt());
+        assertEquals(createdAt, entity.getCreatedAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/EmailVerificationRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/EmailVerificationRepositoryImplTest.java
@@ -1,0 +1,74 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.repository.JpaEmailVerificationRepository;
+import ru.jerael.booktracker.backend.data.mapper.EmailVerificationDataMapper;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({EmailVerificationRepositoryImpl.class, EmailVerificationDataMapper.class})
+class EmailVerificationRepositoryImplTest {
+
+    @Autowired
+    private EmailVerificationRepositoryImpl emailVerificationRepository;
+
+    @Autowired
+    private JpaEmailVerificationRepository jpaEmailVerificationRepository;
+
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String email = "test@example.com";
+    private final VerificationType type = VerificationType.REGISTRATION;
+    private final String token = "token";
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+    private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    @Test
+    void deleteByUserIdAndType_ShouldDeleteEmailVerificationByUserIdAndType() {
+        EmailVerification emailVerification =
+            new EmailVerification(null, userId, email, type, token, expiresAt, createdAt);
+
+        EmailVerification createdEmailVerification = emailVerificationRepository.save(emailVerification);
+        assertNotNull(createdEmailVerification.id());
+
+        emailVerificationRepository.deleteByUserIdAndType(userId, type);
+        assertEquals(Optional.empty(), emailVerificationRepository.findByUserIdAndType(userId, type));
+    }
+
+    @Test
+    void findByUserIdAndType_WhenExists_ShouldReturnEmailVerification() {
+        EmailVerification emailVerification =
+            new EmailVerification(null, userId, email, type, token, expiresAt, createdAt);
+
+        EmailVerification createdEmailVerification = emailVerificationRepository.save(emailVerification);
+        assertNotNull(createdEmailVerification.id());
+
+        Optional<EmailVerification> result = emailVerificationRepository.findByUserIdAndType(userId, type);
+
+        assertTrue(result.isPresent());
+        assertEquals(userId, result.get().userId());
+        assertEquals(email, result.get().email());
+        assertEquals(type, result.get().type());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewEmailVerification() {
+        EmailVerification emailVerification =
+            new EmailVerification(null, userId, email, type, token, expiresAt, createdAt);
+
+        EmailVerification createdEmailVerification = emailVerificationRepository.save(emailVerification);
+
+        assertNotNull(createdEmailVerification.id());
+        assertEquals(userId, createdEmailVerification.userId());
+        assertEquals(email, createdEmailVerification.email());
+        assertEquals(type, createdEmailVerification.type());
+        assertTrue(jpaEmailVerificationRepository.existsById(createdEmailVerification.id()));
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/smtp/SmtpServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/smtp/SmtpServiceImplTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import ru.jerael.booktracker.backend.config.TestcontainersConfiguration;
 import ru.jerael.booktracker.backend.domain.mail.VerificationMailMessage;
-import ru.jerael.booktracker.backend.domain.model.verification.VerificationCode;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationToken;
 import ru.jerael.booktracker.backend.domain.storage.BookCoverStorage;
 import java.time.Duration;
 import static ch.martinelli.oss.testcontainers.mailpit.assertions.MailpitAssertions.assertThat;
@@ -32,8 +32,8 @@ class SmtpServiceImplTest {
     void sendEmail_ShouldSendVerificationMessage() {
         String to = "user@example.com";
         String code = "123456";
-        VerificationCode verificationCode = new VerificationCode(code, Duration.ofMinutes(10L));
-        VerificationMailMessage mailMessage = new VerificationMailMessage(verificationCode);
+        VerificationToken verificationToken = new VerificationToken(code, Duration.ofMinutes(10L));
+        VerificationMailMessage mailMessage = new VerificationMailMessage(verificationToken);
 
         smtpService.sendEmail(to, mailMessage);
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/verification/OtpCodeGeneratorTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/verification/OtpCodeGeneratorTest.java
@@ -2,7 +2,7 @@ package ru.jerael.booktracker.backend.data.verification;
 
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.verification.config.OtpCodeProperties;
-import ru.jerael.booktracker.backend.domain.model.verification.VerificationCode;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationToken;
 import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,24 +23,24 @@ class OtpCodeGeneratorTest {
 
     @Test
     void generate_ShouldReturnCodeWithCorrectLengthAndExpiry() {
-        VerificationCode code = generator.generate();
+        VerificationToken token = generator.generate();
 
-        assertEquals(CODE_LENGTH, code.value().length());
-        assertEquals(EXPIRY, code.expiry());
+        assertEquals(CODE_LENGTH, token.value().length());
+        assertEquals(EXPIRY, token.expiry());
     }
 
     @Test
     void generate_ShouldContainsOnlyDigits() {
-        VerificationCode code = generator.generate();
+        VerificationToken token = generator.generate();
 
-        assertThat(code.value()).containsOnlyDigits();
+        assertThat(token.value()).containsOnlyDigits();
     }
 
     @Test
     void generate_ShouldReturnDifferentCodes() {
-        VerificationCode code1 = generator.generate();
-        VerificationCode code2 = generator.generate();
+        VerificationToken token1 = generator.generate();
+        VerificationToken token2 = generator.generate();
 
-        assertNotEquals(code1.value(), code2.value());
+        assertNotEquals(token1.value(), token2.value());
     }
 }

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -17,3 +17,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/09__set-archive-user-id-to-all-books.yaml
   - include:
       file: classpath:/db/changelog/changes/10__set-user_id-not-null-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/11__email_verifications-schema.yaml


### PR DESCRIPTION
### What does this PR do?

- Added migration for `email_verifications` table via Liquibase.
- Implemented `EmailVerificationRepository` and `EmailVerificationDataMapper`.
- Implemented `EmailVerificationService` to orchestrate the lifecycle of verification tokens (initiation and confirmation).
- Created `VerificationTokenValidator` to handle business rules for token expiration and matching.
- Refactored terminology from `Code` to `Token` across the verification sub-system.

Tests:
- Added tests for `EmailVerificationRepository`, `EmailVerificationDataMapper`, `EmailVerificationService` and `VerificationTokenValidator`.

### Related tickets

Part of #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
