### PR TITLE
feat: add registration endpoint and use case

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/EmailVerificationServiceImpl.java
@@ -24,7 +24,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     @Override
     @Transactional
-    public void initiate(EmailVerificationInitiation payload) {
+    public Instant initiate(EmailVerificationInitiation payload) {
         UUID userId = payload.userId();
         String email = payload.email();
         VerificationType type = payload.type();
@@ -33,18 +33,21 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
         VerificationToken token = verificationTokenGenerator.generate();
 
+        Instant expiresAt = Instant.now().plusMillis(token.expiry().toMillis());
         EmailVerification emailVerification = new EmailVerification(
             null,
             userId,
             email,
             type,
             token.value(),
-            Instant.now().plusMillis(token.expiry().toMillis()),
+            expiresAt,
             Instant.now()
         );
         emailVerificationRepository.save(emailVerification);
 
         smtpService.sendEmail(email, new VerificationMailMessage(token));
+
+        return expiresAt;
     }
 
     @Override

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/user/CreateUserUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/user/CreateUserUseCaseImpl.java
@@ -1,0 +1,49 @@
+package ru.jerael.booktracker.backend.application.usecase.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationInitiation;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
+import ru.jerael.booktracker.backend.domain.validator.UserValidator;
+import ru.jerael.booktracker.backend.domain.verification.EmailVerificationService;
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserUseCaseImpl implements CreateUserUseCase {
+    private final UserRepository userRepository;
+    private final PasswordHasher passwordHasher;
+    private final UserValidator userValidator;
+    private final EmailVerificationService emailVerificationService;
+
+    @Override
+    @Transactional
+    public UserCreationResult execute(UserCreation data) {
+        userValidator.validateCreation(data);
+        if (userRepository.findByEmail(data.email()).isPresent()) {
+            throw UserExceptionFactory.emailAlreadyExists(data.email());
+        }
+        String passwordHash = passwordHasher.hash(data.password());
+        User newUser = new User(null, data.email(), passwordHash, false, Instant.now());
+        User createdUser = userRepository.save(newUser);
+        EmailVerificationInitiation initiation = new EmailVerificationInitiation(
+            createdUser.id(),
+            createdUser.email(),
+            VerificationType.REGISTRATION
+        );
+        Instant expiresAt = emailVerificationService.initiate(initiation);
+        return new UserCreationResult(
+            createdUser.id(),
+            createdUser.email(),
+            expiresAt
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/AlreadyExistsException.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/AlreadyExistsException.java
@@ -1,0 +1,9 @@
+package ru.jerael.booktracker.backend.domain.exception;
+
+import ru.jerael.booktracker.backend.domain.exception.code.ErrorCode;
+
+public class AlreadyExistsException extends AppException {
+    public AlreadyExistsException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/code/UserErrorCode.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/code/UserErrorCode.java
@@ -1,0 +1,5 @@
+package ru.jerael.booktracker.backend.domain.exception.code;
+
+public enum UserErrorCode implements ErrorCode {
+    EMAIL_ALREADY_EXISTS
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/UserExceptionFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/UserExceptionFactory.java
@@ -1,0 +1,13 @@
+package ru.jerael.booktracker.backend.domain.exception.factory;
+
+import ru.jerael.booktracker.backend.domain.exception.AlreadyExistsException;
+import ru.jerael.booktracker.backend.domain.exception.code.UserErrorCode;
+
+public class UserExceptionFactory {
+    public static AlreadyExistsException emailAlreadyExists(String email) {
+        return new AlreadyExistsException(
+            UserErrorCode.EMAIL_ALREADY_EXISTS,
+            "User with email " + email + " already exists"
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/user/UserCreationResult.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/user/UserCreationResult.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.domain.model.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserCreationResult(
+    UUID userId,
+    String email,
+    Instant expiresAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/user/CreateUserUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/user/CreateUserUseCase.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.usecase.user;
+
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+
+public interface CreateUserUseCase {
+    UserCreationResult execute(UserCreation data);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/verification/EmailVerificationService.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/verification/EmailVerificationService.java
@@ -3,9 +3,10 @@ package ru.jerael.booktracker.backend.domain.verification;
 import ru.jerael.booktracker.backend.domain.model.verification.EmailVerification;
 import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationConfirmation;
 import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationInitiation;
+import java.time.Instant;
 
 public interface EmailVerificationService {
-    void initiate(EmailVerificationInitiation payload);
+    Instant initiate(EmailVerificationInitiation payload);
 
     EmailVerification confirm(EmailVerificationConfirmation payload);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
@@ -1,0 +1,32 @@
+package ru.jerael.booktracker.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
+
+@Tag(name = "Auth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final UserWebMapper userWebMapper;
+    private final CreateUserUseCase createUserUseCase;
+
+    @Operation(summary = "Register new user")
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserCreationResponse register(@Valid @RequestBody UserCreationRequest request) {
+        UserCreation data = userWebMapper.toDomain(request);
+        UserCreationResult result = createUserUseCase.execute(data);
+        return userWebMapper.toResponse(result);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/user/UserCreationRequest.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/user/UserCreationRequest.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.web.dto.user;
+
+public record UserCreationRequest(
+    String email,
+    String password
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/user/UserCreationResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/user/UserCreationResponse.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.web.dto.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserCreationResponse(
+    UUID userId,
+    String email,
+    Instant expiresAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/exception/handler/GlobalExceptionHandler.java
@@ -17,10 +17,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
-import ru.jerael.booktracker.backend.domain.exception.AppException;
-import ru.jerael.booktracker.backend.domain.exception.InternalException;
-import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
-import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.exception.*;
 import ru.jerael.booktracker.backend.domain.exception.code.CommonErrorCode;
 import ru.jerael.booktracker.backend.domain.exception.code.ErrorCode;
 import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
@@ -43,6 +40,16 @@ public class GlobalExceptionHandler {
             HttpStatus.NOT_FOUND,
             ex.getMessage(),
             "Resource not found",
+            ex.getErrorCode()
+        );
+    }
+
+    @ExceptionHandler(AlreadyExistsException.class)
+    public ProblemDetail handleAlreadyExistsException(AlreadyExistsException ex) {
+        return buildProblemDetail(
+            HttpStatus.CONFLICT,
+            ex.getMessage(),
+            "Already exists",
             ex.getErrorCode()
         );
     }

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapper.java
@@ -1,0 +1,29 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+
+@Component
+public class UserWebMapper {
+    public UserCreationResponse toResponse(UserCreationResult result) {
+        if (result == null) return null;
+
+        return new UserCreationResponse(
+            result.userId(),
+            result.email(),
+            result.expiresAt()
+        );
+    }
+
+    public UserCreation toDomain(UserCreationRequest request) {
+        if (request == null) return null;
+
+        return new UserCreation(
+            request.email(),
+            request.password()
+        );
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/user/CreateUserUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/user/CreateUserUseCaseImplTest.java
@@ -1,0 +1,92 @@
+package ru.jerael.booktracker.backend.application.usecase.user;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.domain.exception.AlreadyExistsException;
+import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationInitiation;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import ru.jerael.booktracker.backend.domain.validator.UserValidator;
+import ru.jerael.booktracker.backend.domain.verification.EmailVerificationService;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateUserUseCaseImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordHasher passwordHasher;
+
+    @Mock
+    private UserValidator userValidator;
+
+    @Mock
+    private EmailVerificationService emailVerificationService;
+
+    @InjectMocks
+    private CreateUserUseCaseImpl useCase;
+
+    private final String email = "test@example.com";
+    private final String password = "Password123!";
+    private final String passwordHash = "password hash";
+    private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+
+    private final UserCreation userCreation = new UserCreation(email, password);
+    private final User user = new User(id, email, passwordHash, false, Instant.now());
+    private final Instant expiresAt = Instant.now().plusSeconds(1000L);
+
+    @Test
+    void execute_WhenEmailIsNotTaken_ShouldCreateUserAndInitiateVerification() {
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(passwordHasher.hash(password)).thenReturn(passwordHash);
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        when(emailVerificationService.initiate(any(EmailVerificationInitiation.class))).thenReturn(expiresAt);
+
+        UserCreationResult result = useCase.execute(userCreation);
+
+        assertNotNull(result);
+        assertEquals(id, result.userId());
+        assertEquals(email, result.email());
+        assertEquals(expiresAt, result.expiresAt());
+
+        verify(userValidator).validateCreation(userCreation);
+        verify(userRepository).findByEmail(email);
+        verify(passwordHasher).hash(password);
+        verify(userRepository).save(any(User.class));
+
+        ArgumentCaptor<EmailVerificationInitiation> captor = ArgumentCaptor.forClass(EmailVerificationInitiation.class);
+        verify(emailVerificationService).initiate(captor.capture());
+        assertEquals(id, captor.getValue().userId());
+        assertEquals(email, captor.getValue().email());
+        assertEquals(VerificationType.REGISTRATION, captor.getValue().type());
+    }
+
+    @Test
+    void execute_WhenEmailIsTaken_ShouldThrowException() {
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        assertThrows(AlreadyExistsException.class, () -> useCase.execute(userCreation));
+
+        verify(userValidator).validateCreation(userCreation);
+        verify(userRepository).findByEmail(email);
+        verifyNoInteractions(passwordHasher);
+        verifyNoInteractions(emailVerificationService);
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
@@ -1,0 +1,84 @@
+package ru.jerael.booktracker.backend.web.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
+import ru.jerael.booktracker.backend.web.config.WebProperties;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
+import tools.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(AuthController.class)
+@Import(UserWebMapper.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvcTester;
+
+    @MockitoBean
+    private WebProperties webProperties;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CreateUserUseCase createUserUseCase;
+
+    private final String email = "test@example.com";
+    private final String password = "Password123!";
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+
+    @Test
+    void register_ShouldReturnCreatedUser() {
+        UserCreationRequest request = new UserCreationRequest(email, password);
+        UserCreationResult mockResult = new UserCreationResult(userId, email, expiresAt);
+        when(createUserUseCase.execute(any(UserCreation.class))).thenReturn(mockResult);
+
+        assertThat(
+            mockMvcTester.post().uri("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .hasStatus(HttpStatus.CREATED)
+            .bodyJson()
+            .convertTo(UserCreationResponse.class)
+            .satisfies(response -> {
+                assertThat(response.userId()).isEqualTo(userId);
+                assertThat(response.email()).isEqualTo(email);
+                assertThat(response.expiresAt()).isEqualTo(expiresAt);
+            });
+    }
+
+    @Test
+    void register_WhenEmailAlreadyExists_ShouldReturnConflict() {
+        String existingEmail = "existing@example.com";
+        UserCreationRequest request = new UserCreationRequest(existingEmail, password);
+        when(createUserUseCase.execute(any(UserCreation.class)))
+            .thenThrow(UserExceptionFactory.emailAlreadyExists(existingEmail));
+
+        assertThat(
+            mockMvcTester.post().uri("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .hasStatus(HttpStatus.CONFLICT)
+            .bodyJson()
+            .extractingPath("$.detail").asString().contains(existingEmail);
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/web/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/exception/handler/GlobalExceptionHandlerTest.java
@@ -18,14 +18,16 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.NoHandlerFoundException;
-import ru.jerael.booktracker.backend.web.config.WebProperties;
-import ru.jerael.booktracker.backend.web.exception.code.WebErrorCode;
-import ru.jerael.booktracker.backend.web.exception.factory.FileWebExceptionFactory;
 import ru.jerael.booktracker.backend.domain.exception.AppException;
 import ru.jerael.booktracker.backend.domain.exception.code.BookErrorCode;
 import ru.jerael.booktracker.backend.domain.exception.code.CommonErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.code.UserErrorCode;
 import ru.jerael.booktracker.backend.domain.exception.factory.BookExceptionFactory;
 import ru.jerael.booktracker.backend.domain.exception.factory.FileValidationExceptionFactory;
+import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.web.config.WebProperties;
+import ru.jerael.booktracker.backend.web.exception.code.WebErrorCode;
+import ru.jerael.booktracker.backend.web.exception.factory.FileWebExceptionFactory;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -50,6 +52,11 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/test/not-found")
         void notFound() {
             throw BookExceptionFactory.bookNotFound(id);
+        }
+
+        @GetMapping("/test/already-exists")
+        void alreadyExists() {
+            throw UserExceptionFactory.emailAlreadyExists("test@example.com");
         }
 
         @GetMapping("/test/validation")
@@ -108,6 +115,16 @@ class GlobalExceptionHandlerTest {
         json.extractingPath("$.detail").isEqualTo("Book with id " + id + " was not found");
         json.extractingPath("$.title").isEqualTo("Resource not found");
         json.extractingPath("$.code").isEqualTo(BookErrorCode.BOOK_NOT_FOUND.name());
+    }
+
+    @Test
+    void handleAlreadyExistsException() {
+        var response = mockMvcTester.get().uri("/test/already-exists");
+        assertThat(response).hasStatus(HttpStatus.CONFLICT);
+        var json = assertThat(response).bodyJson();
+        json.extractingPath("$.detail").isEqualTo("User with email test@example.com already exists");
+        json.extractingPath("$.title").isEqualTo("Already exists");
+        json.extractingPath("$.code").isEqualTo(UserErrorCode.EMAIL_ALREADY_EXISTS.name());
     }
 
     @Test

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapperTest.java
@@ -1,0 +1,43 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
+import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class UserWebMapperTest {
+    private final UserWebMapper userWebMapper = new UserWebMapper();
+
+    private final String email = "test@example.com";
+    private final String password = "password";
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+
+    @Test
+    void toResponse() {
+        UserCreationResult result = new UserCreationResult(userId, email, expiresAt);
+
+        UserCreationResponse response = userWebMapper.toResponse(result);
+
+        assertNotNull(response);
+        assertEquals(userId, response.userId());
+        assertEquals(email, response.email());
+        assertEquals(expiresAt, response.expiresAt());
+    }
+
+    @Test
+    void toDomain() {
+        UserCreationRequest request = new UserCreationRequest(email, password);
+
+        UserCreation domain = userWebMapper.toDomain(request);
+
+        assertNotNull(domain);
+        assertEquals(email, domain.email());
+        assertEquals(password, domain.password());
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- `EmailVerificationService.initiate` now returns `expiresAt`.
- Added `AlreadyExistsException` and handler in `GlobalExceptionHandler`.
- Added `CreateUserUseCase` and its implementation `CreateUserUseCaseImpl`.
- Added `AuthController` with a `POST /auth/register` endpoint.
- Added `UserWebMapper`.

Tests:
- Added tests for `CreateUserUseCaseImpl`, `AuthController`, `GlobalExceptionHandler` and `UserWebMapper`.

### Related tickets

Part of #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
