### PR TITLE
feat: add refresh tokens table and repository

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -9,4 +9,5 @@ public class Tables {
     public final String BOOK_GENRES = "book_genres";
     public final String USERS = "users";
     public final String EMAIL_VERIFICATIONS = "email_verifications";
+    public final String REFRESH_TOKENS = "refresh_tokens";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/RefreshTokenEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/RefreshTokenEntity.java
@@ -1,0 +1,31 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.AuthRules;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Table(name = Tables.REFRESH_TOKENS)
+@Entity
+@NoArgsConstructor
+public class RefreshTokenEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "token_hash", length = AuthRules.REFRESH_TOKEN_HASH_MAX_LENGTH, nullable = false)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaRefreshTokenRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaRefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import java.util.UUID;
+
+@Repository
+public interface JpaRefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapper.java
@@ -1,0 +1,19 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+
+@Component
+public class RefreshTokenDataMapper {
+    public RefreshTokenEntity toEntity(RefreshToken refreshToken) {
+        if (refreshToken == null) return null;
+
+        RefreshTokenEntity entity = new RefreshTokenEntity();
+        entity.setId(refreshToken.id());
+        entity.setUserId(refreshToken.userId());
+        entity.setTokenHash(refreshToken.tokenHash());
+        entity.setExpiresAt(refreshToken.expiresAt());
+        return entity;
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,22 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaRefreshTokenRepository;
+import ru.jerael.booktracker.backend.data.mapper.RefreshTokenDataMapper;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+    private final JpaRefreshTokenRepository jpaRefreshTokenRepository;
+    private final RefreshTokenDataMapper refreshTokenDataMapper;
+
+    @Override
+    public void save(RefreshToken refreshToken) {
+        RefreshTokenEntity entity = refreshTokenDataMapper.toEntity(refreshToken);
+        jpaRefreshTokenRepository.save(entity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/AuthRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/AuthRules.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class AuthRules {
+    private AuthRules() {}
+
+    public static final int REFRESH_TOKEN_HASH_MAX_LENGTH = 255;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/RefreshToken.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/RefreshToken.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record RefreshToken(
+    UUID id,
+    UUID userId,
+    String tokenHash,
+    Instant expiresAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+
+public interface RefreshTokenRepository {
+    void save(RefreshToken refreshToken);
+}

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -21,3 +21,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/10__set-user_id-not-null-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/11__email_verifications-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/12__refresh_tokens-schema.yaml

--- a/src/main/resources/db/changelog/changes/12__refresh_tokens-schema.yaml
+++ b/src/main/resources/db/changelog/changes/12__refresh_tokens-schema.yaml
@@ -1,0 +1,59 @@
+databaseChangeLog:
+  - changeSet:
+      id: 12__create-refresh_tokens-table
+      author: Jerael
+      comment: create refresh_tokens table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: refresh_tokens
+      changes:
+        - createTable:
+            tableName: refresh_tokens
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: token_hash
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: refresh_tokens
+            columnNames: id
+            constraintName: pk_refresh_tokens
+        - addForeignKeyConstraint:
+            baseTableName: refresh_tokens
+            baseColumnNames: user_id
+            referencedTableName: users
+            referencedColumnNames: user_id
+            constraintName: fk_refresh_tokens_user_id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_refresh_tokens_user_id
+            using: btree
+            tableName: refresh_tokens
+            columns:
+              - column:
+                  name: user_id
+        - createIndex:
+            indexName: idx_refresh_tokens_expires_at
+            using: btree
+            tableName: refresh_tokens
+            columns:
+              - column:
+                  name: expires_at

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapperTest.java
@@ -1,0 +1,29 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.Assert.assertEquals;
+
+class RefreshTokenDataMapperTest {
+    private final RefreshTokenDataMapper refreshTokenDataMapper = new RefreshTokenDataMapper();
+
+    private final UUID id = UUID.fromString("2119fe3a-4067-4557-99c6-c28addc2cdd9");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String tokenHash = "token hash";
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+
+    @Test
+    void toEntity() {
+        RefreshToken refreshToken = new RefreshToken(id, userId, tokenHash, expiresAt);
+
+        RefreshTokenEntity entity = refreshTokenDataMapper.toEntity(refreshToken);
+
+        assertEquals(id, entity.getId());
+        assertEquals(userId, entity.getUserId());
+        assertEquals(tokenHash, entity.getTokenHash());
+        assertEquals(expiresAt, entity.getExpiresAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
@@ -1,0 +1,45 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaRefreshTokenRepository;
+import ru.jerael.booktracker.backend.data.mapper.RefreshTokenDataMapper;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.Assert.assertEquals;
+
+@DataJpaTest
+@Import({RefreshTokenRepositoryImpl.class, RefreshTokenDataMapper.class})
+class RefreshTokenRepositoryImplTest {
+
+    @Autowired
+    private RefreshTokenRepositoryImpl refreshTokenRepository;
+
+    @Autowired
+    private JpaRefreshTokenRepository jpaRefreshTokenRepository;
+
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String tokenHash = "token hash";
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+
+    @Test
+    void save() {
+        RefreshToken refreshToken = new RefreshToken(null, userId, tokenHash, expiresAt);
+
+        refreshTokenRepository.save(refreshToken);
+
+        List<RefreshTokenEntity> entities = jpaRefreshTokenRepository.findAll();
+
+        assertEquals(1, entities.size());
+
+        RefreshTokenEntity entity = entities.get(0);
+        assertEquals(userId, entity.getUserId());
+        assertEquals(tokenHash, entity.getTokenHash());
+        assertEquals(expiresAt, entity.getExpiresAt());
+    }
+}

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -19,3 +19,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/10__set-user_id-not-null-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/11__email_verifications-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/12__refresh_tokens-schema.yaml


### PR DESCRIPTION
### What does this PR do?

- Added migration for `refresh_tokens` table via Liquibase.
- Added `RefreshTokenEntity`.
- Added `RefreshToken` Domain model and `RefreshTokenDataMapper`.
- Implemented `RefreshTokenRepositoryImpl`.

Tests:
- Added tests for `RefreshTokenRepositoryImpl` and `RefreshTokenDataMapper`.

### Related tickets

Part of #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
