### PR TITLE
feat: implement auth token service

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImpl.java
@@ -1,0 +1,33 @@
+package ru.jerael.booktracker.backend.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
+import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthTokenServiceImpl implements AuthTokenService {
+    private final IdentityTokenProvider identityTokenProvider;
+    private final PasswordHasher passwordHasher;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    @Transactional
+    public TokenPair issueTokens(UUID userId) {
+        Map<String, Object> claims = Map.of("sub", userId);
+        String accessToken = identityTokenProvider.generateAccessToken(claims);
+        GeneratedToken refreshToken = identityTokenProvider.generateRefreshToken();
+        String hash = passwordHasher.hash(refreshToken.value());
+        refreshTokenRepository.save(new RefreshToken(null, userId, hash, refreshToken.expiresAt()));
+        return new TokenPair(accessToken, refreshToken.value());
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
@@ -24,20 +24,19 @@ public class JwtProvider implements IdentityTokenProvider {
     private final JWSAlgorithm jwsAlgorithm = JWSAlgorithm.HS256;
 
     @Override
-    public String generateAccessToken(UUID userId) {
+    public String generateAccessToken(Map<String, Object> claims) {
         Instant now = Instant.now();
         Instant expiresAt = now.plus(properties.getAccessExpiry());
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
-            .subject(userId.toString())
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
             .issuer(properties.getIssuer())
             .issueTime(Date.from(now))
-            .expirationTime(Date.from(expiresAt))
-            .build();
-        return signJWT(jwtClaimsSet);
+            .expirationTime(Date.from(expiresAt));
+        claims.forEach(builder::claim);
+        return signJWT(builder.build());
     }
 
     @Override
-    public GeneratedToken generateRefreshToken(UUID userId) {
+    public GeneratedToken generateRefreshToken() {
         String value = UUID.randomUUID().toString();
         Instant expiresAt = Instant.now().plus(properties.getRefreshExpiry());
         return new GeneratedToken(value, expiresAt);

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/TokenPair.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/TokenPair.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+public record TokenPair(
+    String accessToken,
+    String refreshToken
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/AuthTokenService.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/AuthTokenService.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.service.token;
+
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import java.util.UUID;
+
+public interface AuthTokenService {
+    TokenPair issueTokens(UUID userId);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
@@ -2,12 +2,11 @@ package ru.jerael.booktracker.backend.domain.service.token;
 
 import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
 import java.util.Map;
-import java.util.UUID;
 
 public interface IdentityTokenProvider {
-    String generateAccessToken(UUID userId);
+    String generateAccessToken(Map<String, Object> claims);
 
-    GeneratedToken generateRefreshToken(UUID userId);
+    GeneratedToken generateRefreshToken();
 
     Map<String, Object> extractClaims(String token);
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImplTest.java
@@ -1,0 +1,73 @@
+package ru.jerael.booktracker.backend.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
+import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthTokenServiceImplTest {
+
+    @Mock
+    private IdentityTokenProvider identityTokenProvider;
+
+    @Mock
+    private PasswordHasher passwordHasher;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private AuthTokenServiceImpl service;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> claimsCaptor;
+
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+
+    @Test
+    void issueTokens_ShouldSaveHashedRefreshTokenAndReturnTokenPair() {
+        String accessToken = "access token";
+        String refreshToken = "refresh token";
+        String hash = "refresh token hash";
+        when(identityTokenProvider.generateAccessToken(any())).thenReturn(accessToken);
+        when(identityTokenProvider.generateRefreshToken()).thenReturn(new GeneratedToken(refreshToken, expiresAt));
+        when(passwordHasher.hash(refreshToken)).thenReturn(hash);
+
+        TokenPair result = service.issueTokens(userId);
+
+        assertEquals(accessToken, result.accessToken());
+        assertEquals(refreshToken, result.refreshToken());
+
+        verify(identityTokenProvider).generateAccessToken(claimsCaptor.capture());
+        Map<String, Object> capturedClaims = claimsCaptor.getValue();
+        assertEquals(userId, capturedClaims.get("sub"));
+
+        verify(passwordHasher).hash(refreshToken);
+
+        ArgumentCaptor<RefreshToken> refreshTokenCaptor = ArgumentCaptor.forClass(RefreshToken.class);
+        verify(refreshTokenRepository).save(refreshTokenCaptor.capture());
+
+        RefreshToken savedToken = refreshTokenCaptor.getValue();
+        assertEquals(userId, savedToken.userId());
+        assertEquals(hash, savedToken.tokenHash());
+        assertEquals(expiresAt, savedToken.expiresAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
@@ -27,6 +27,7 @@ class JwtProviderTest {
     private final String issuer = "issuer";
 
     private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final Map<String, Object> claims = Map.of("sub", userId);
 
     public JwtProviderTest() {
         JwtProperties properties = new JwtProperties();
@@ -39,7 +40,7 @@ class JwtProviderTest {
 
     @Test
     void generateAccessToken_ShouldCreateValidSignedJwt() {
-        String token = jwtProvider.generateAccessToken(userId);
+        String token = jwtProvider.generateAccessToken(claims);
 
         assertThat(token).isNotBlank();
         assertEquals(3, token.split("\\.").length);
@@ -47,7 +48,7 @@ class JwtProviderTest {
 
     @Test
     void generateRefreshToken_ShouldCreateValidUuidAndExpiry() {
-        GeneratedToken generatedToken = jwtProvider.generateRefreshToken(userId);
+        GeneratedToken generatedToken = jwtProvider.generateRefreshToken();
 
         assertThat(generatedToken.value()).isNotBlank();
         assertNotNull(UUID.fromString(generatedToken.value()));
@@ -56,17 +57,17 @@ class JwtProviderTest {
 
     @Test
     void extractClaims_WhenTokenIsValid_ShouldReturnCorrectClaims() {
-        String token = jwtProvider.generateAccessToken(userId);
+        String token = jwtProvider.generateAccessToken(claims);
 
-        Map<String, Object> claims = jwtProvider.extractClaims(token);
+        Map<String, Object> result = jwtProvider.extractClaims(token);
 
-        assertThat(claims.get("sub")).isEqualTo(userId.toString());
-        assertThat(claims.get("iss")).isEqualTo(issuer);
+        assertThat(result.get("sub")).isEqualTo(userId.toString());
+        assertThat(result.get("iss")).isEqualTo(issuer);
     }
 
     @Test
     void extractClaims_WhenSignatureIsInvalid_ShouldThrowException() {
-        String validToken = jwtProvider.generateAccessToken(userId);
+        String validToken = jwtProvider.generateAccessToken(claims);
         String invalidToken = validToken.substring(0, validToken.length() - 10);
 
         Throwable throwable =
@@ -77,10 +78,11 @@ class JwtProviderTest {
 
     @Test
     void extractClaims_WhenTokenIsExpired_ShouldThrowException() throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
-            .subject(userId.toString())
-            .expirationTime(Date.from(Instant.now().minusSeconds(10)))
-            .build();
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+            .expirationTime(Date.from(Instant.now().minusSeconds(10)));
+        claims.forEach(builder::claim);
+
+        JWTClaimsSet jwtClaimsSet = builder.build();
 
         JWSSigner jwsSigner = new MACSigner(secret);
         SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), jwtClaimsSet);
@@ -97,11 +99,13 @@ class JwtProviderTest {
     @Test
     void extractClaims_WhenIssuerIsInvalid_ShouldThrowException() throws Exception {
         String wrongIssuer = "wrong issuer";
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
-            .subject(userId.toString())
+
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
             .issuer(wrongIssuer)
-            .expirationTime(Date.from(Instant.now().plus(accessExpiry)))
-            .build();
+            .expirationTime(Date.from(Instant.now().plus(accessExpiry)));
+        claims.forEach(builder::claim);
+
+        JWTClaimsSet jwtClaimsSet = builder.build();
 
         JWSSigner jwsSigner = new MACSigner(secret);
         SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), jwtClaimsSet);


### PR DESCRIPTION
### What does this PR do?

- Added `TokenPair` Domain model with `accessToken` and `refreshToken`.
- Added support custom data in `IdentityTokenProvider.generateAccessToken` and removing unused argument in `generateRefreshToken`.
- Added `AuthTokenService` and its implementation `AuthTokenServiceImpl` in application layer.

Tests:
- Added tests for `AuthTokenServiceImpl`.

### Related tickets

Part of #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
