### PR TITLE
feat: implement confirm registration use case

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/ConfirmRegistrationUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/ConfirmRegistrationUseCaseImpl.java
@@ -1,0 +1,53 @@
+package ru.jerael.booktracker.backend.application.usecase.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationConfirmation;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import ru.jerael.booktracker.backend.domain.verification.EmailVerificationService;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ConfirmRegistrationUseCaseImpl implements ConfirmRegistrationUseCase {
+    private final AuthValidator authValidator;
+    private final UserRepository userRepository;
+    private final EmailVerificationService emailVerificationService;
+    private final AuthTokenService authTokenService;
+
+    @Override
+    @Transactional
+    public TokenPair execute(ConfirmRegistration data) {
+        authValidator.validateRegistrationConfirmation(data);
+        UUID userId = data.userId();
+        User user =
+            userRepository.findById(userId).orElseThrow(() -> UserExceptionFactory.userNotFound(userId));
+        if (user.isVerified()) {
+            throw UserExceptionFactory.userAlreadyVerified(userId);
+        }
+        EmailVerificationConfirmation emailVerificationConfirmation = new EmailVerificationConfirmation(
+            userId,
+            data.token(),
+            VerificationType.REGISTRATION
+        );
+        emailVerificationService.confirm(emailVerificationConfirmation);
+        User verifiedUser = new User(
+            userId,
+            user.email(),
+            user.passwordHash(),
+            true,
+            user.createdAt()
+        );
+        userRepository.save(verifiedUser);
+        return authTokenService.issueTokens(userId);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
@@ -1,0 +1,43 @@
+package ru.jerael.booktracker.backend.application.validator;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class AuthValidatorImpl implements AuthValidator {
+    @Override
+    public void validateRegistrationConfirmation(ConfirmRegistration data) {
+        List<ValidationError> errors = new ArrayList<>();
+        UUID userId = data.userId();
+        String token = data.token();
+
+        if (userId == null) {
+            errors.add(CommonValidationErrorFactory.emptyField("userId"));
+        }
+
+        if (token == null || token.isBlank()) {
+            errors.add(CommonValidationErrorFactory.emptyField("token"));
+        } else {
+            if (token.length() < EmailVerificationRules.TOKEN_MIN_LENGTH) {
+                errors.add(
+                    CommonValidationErrorFactory.fieldTooShort("token", EmailVerificationRules.TOKEN_MIN_LENGTH));
+            }
+            if (token.length() > EmailVerificationRules.TOKEN_MAX_LENGTH) {
+                errors.add(
+                    CommonValidationErrorFactory.fieldTooLong("token", EmailVerificationRules.TOKEN_MAX_LENGTH));
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new ValidationException(errors);
+        }
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/verification/config/OtpCodeProperties.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/verification/config/OtpCodeProperties.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
+import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
 import java.time.Duration;
 
 @Component
@@ -13,8 +14,8 @@ import java.time.Duration;
 @ConfigurationProperties(prefix = "app.otp")
 @Validated
 public class OtpCodeProperties {
-    @Min(1)
-    @Max(64)
+    @Min(EmailVerificationRules.TOKEN_MIN_LENGTH)
+    @Max(EmailVerificationRules.TOKEN_MAX_LENGTH)
     private int length = 6;
 
     private Duration expiry = Duration.ofMinutes(10);

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/EmailVerificationRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/EmailVerificationRules.java
@@ -4,5 +4,7 @@ public final class EmailVerificationRules {
     private EmailVerificationRules() {}
 
     public static final int TYPE_MAX_LENGTH = 255;
+
+    public static final int TOKEN_MIN_LENGTH = 6;
     public static final int TOKEN_MAX_LENGTH = 255;
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/code/UserErrorCode.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/code/UserErrorCode.java
@@ -1,5 +1,7 @@
 package ru.jerael.booktracker.backend.domain.exception.code;
 
 public enum UserErrorCode implements ErrorCode {
-    EMAIL_ALREADY_EXISTS
+    EMAIL_ALREADY_EXISTS,
+    USER_NOT_FOUND,
+    ALREADY_VERIFIED
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/UserExceptionFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/exception/factory/UserExceptionFactory.java
@@ -1,7 +1,13 @@
 package ru.jerael.booktracker.backend.domain.exception.factory;
 
 import ru.jerael.booktracker.backend.domain.exception.AlreadyExistsException;
+import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.code.UserErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class UserExceptionFactory {
     public static AlreadyExistsException emailAlreadyExists(String email) {
@@ -9,5 +15,23 @@ public class UserExceptionFactory {
             UserErrorCode.EMAIL_ALREADY_EXISTS,
             "User with email " + email + " already exists"
         );
+    }
+
+    public static NotFoundException userNotFound(UUID id) {
+        return new NotFoundException(
+            UserErrorCode.USER_NOT_FOUND,
+            "User with id " + id + " was not found"
+        );
+    }
+
+    public static ValidationException userAlreadyVerified(UUID id) {
+        return new ValidationException(List.of(
+            new ValidationError(
+                UserErrorCode.ALREADY_VERIFIED.name(),
+                "userId",
+                "User with id " + id + " already verified",
+                Map.of()
+            )
+        ));
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/ConfirmRegistration.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/ConfirmRegistration.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+import java.util.UUID;
+
+public record ConfirmRegistration(
+    UUID userId,
+    String token
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/auth/ConfirmRegistrationUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/auth/ConfirmRegistrationUseCase.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.usecase.auth;
+
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+
+public interface ConfirmRegistrationUseCase {
+    TokenPair execute(ConfirmRegistration data);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.validator;
+
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+
+public interface AuthValidator {
+    void validateRegistrationConfirmation(ConfirmRegistration data);
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/ConfirmRegistrationUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/ConfirmRegistrationUseCaseImplTest.java
@@ -1,0 +1,91 @@
+package ru.jerael.booktracker.backend.application.usecase.auth;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.model.verification.EmailVerificationConfirmation;
+import ru.jerael.booktracker.backend.domain.model.verification.VerificationType;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import ru.jerael.booktracker.backend.domain.verification.EmailVerificationService;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmRegistrationUseCaseImplTest {
+
+    @Mock
+    private AuthValidator authValidator;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmailVerificationService emailVerificationService;
+
+    @Mock
+    private AuthTokenService authTokenService;
+
+    @InjectMocks
+    private ConfirmRegistrationUseCaseImpl useCase;
+
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final String token = "123456";
+    private final String email = "test@example.com";
+    private final String passwordHash = "password hash";
+    private final ConfirmRegistration confirmRegistration = new ConfirmRegistration(userId, token);
+
+    @Test
+    void execute_ShouldVerifyUserAndDeleteCodeAndReturnTokens() {
+        User unverifiedUser = new User(userId, email, passwordHash, false, Instant.now());
+        TokenPair tokenPair = new TokenPair("access token", "refresh token");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(unverifiedUser));
+        when(authTokenService.issueTokens(userId)).thenReturn(tokenPair);
+
+        TokenPair result = useCase.execute(confirmRegistration);
+
+        verify(authValidator).validateRegistrationConfirmation(confirmRegistration);
+
+        ArgumentCaptor<EmailVerificationConfirmation> confirmCaptor =
+            ArgumentCaptor.forClass(EmailVerificationConfirmation.class);
+        verify(emailVerificationService).confirm(confirmCaptor.capture());
+        assertEquals(userId, confirmCaptor.getValue().userId());
+        assertEquals(token, confirmCaptor.getValue().token());
+        assertEquals(VerificationType.REGISTRATION, confirmCaptor.getValue().type());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertTrue(userCaptor.getValue().isVerified());
+
+        assertEquals(tokenPair, result);
+    }
+
+    @Test
+    void execute_WhenUserNotFound_ShouldThrowException() {
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> useCase.execute(confirmRegistration));
+    }
+
+    @Test
+    void execute_WhenUserAlreadyVerified_ShouldThrowException() {
+        User verifiedUser = new User(userId, email, passwordHash, true, Instant.now());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(verifiedUser));
+
+        assertThrows(ValidationException.class, () -> useCase.execute(confirmRegistration));
+
+        verifyNoInteractions(emailVerificationService);
+        verifyNoInteractions(authTokenService);
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
@@ -1,0 +1,66 @@
+package ru.jerael.booktracker.backend.application.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.exception.code.CommonValidationErrorCode;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AuthValidatorImplTest {
+    private final AuthValidator authValidator = new AuthValidatorImpl();
+
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+
+    @Test
+    void validateRegistrationConfirmation_WhenValid_ShouldNotThrowException() {
+        ConfirmRegistration data = new ConfirmRegistration(userId, "123456");
+
+        assertDoesNotThrow(() -> authValidator.validateRegistrationConfirmation(data));
+    }
+
+    @Test
+    void validateRegistrationConfirmation_WhenUserIdIsNull_ShouldThrowException() {
+        ConfirmRegistration data = new ConfirmRegistration(null, "123456");
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> authValidator.validateRegistrationConfirmation(data));
+
+        assertThat(ex.getErrors()).anyMatch(e -> e.field().equals("userId"));
+    }
+
+    @Test
+    void validateRegistrationConfirmation_WhenTokenIsBlank_ShouldThrowException() {
+        ConfirmRegistration data = new ConfirmRegistration(userId, "  ");
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> authValidator.validateRegistrationConfirmation(data));
+
+        assertThat(ex.getErrors()).anyMatch(e -> e.field().equals("token"));
+    }
+
+    @Test
+    void validateRegistrationConfirmation_WhenTokenTooShort_ShouldThrowException() {
+        ConfirmRegistration data = new ConfirmRegistration(userId, "1");
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> authValidator.validateRegistrationConfirmation(data));
+
+        assertThat(ex.getErrors()).anyMatch(e -> e.code().equals(CommonValidationErrorCode.FIELD_TOO_SHORT.name()));
+    }
+
+    @Test
+    void validateRegistrationConfirmation_WhenTokenTooLong_ShouldThrowException() {
+        String token = "a".repeat(EmailVerificationRules.TOKEN_MAX_LENGTH + 1);
+        ConfirmRegistration data = new ConfirmRegistration(userId, token);
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> authValidator.validateRegistrationConfirmation(data));
+
+        assertThat(ex.getErrors()).anyMatch(e -> e.code().equals(CommonValidationErrorCode.FIELD_TOO_LONG.name()));
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Added `ConfirmRegistration` Domain model.
- Added `userNotFound` and `userAlreadyVerified` exceptions to `UserExceptionFactory`.
- Added `token` length (min, max) from `EmailVerificationRules` to `OtpCodeProperties`.
- Implemented `AuthValidator` with for validating `ConfirmRegistration`.
- Implemented `ConfirmRegistrationUseCase`.

Tests:
- Added tests for `ConfirmRegistrationUseCaseImpl` and `AuthValidatorImpl`.

### Related tickets

Part of #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
