### PR TITLE
feat: implement confirm registration endpoint

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
@@ -6,11 +6,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
+import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
+import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import ru.jerael.booktracker.backend.web.mapper.AuthWebMapper;
 import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
 
 @Tag(name = "Auth")
@@ -19,7 +25,9 @@ import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
 @RequestMapping("/api/v1/auth")
 public class AuthController {
     private final UserWebMapper userWebMapper;
+    private final AuthWebMapper authWebMapper;
     private final CreateUserUseCase createUserUseCase;
+    private final ConfirmRegistrationUseCase confirmRegistrationUseCase;
 
     @Operation(summary = "Register new user")
     @PostMapping("/register")
@@ -28,5 +36,13 @@ public class AuthController {
         UserCreation data = userWebMapper.toDomain(request);
         UserCreationResult result = createUserUseCase.execute(data);
         return userWebMapper.toResponse(result);
+    }
+
+    @Operation(summary = "Confirm registration")
+    @PostMapping("/confirm-registration")
+    public AuthResponse confirmRegistration(@Valid @RequestBody ConfirmRegistrationRequest request) {
+        ConfirmRegistration data = authWebMapper.toDomain(request);
+        TokenPair tokenPair = confirmRegistrationUseCase.execute(data);
+        return authWebMapper.toResponse(tokenPair);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/AuthResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/AuthResponse.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.web.dto.auth;
+
+public record AuthResponse(
+    String accessToken,
+    String refreshToken
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/ConfirmRegistrationRequest.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/ConfirmRegistrationRequest.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.web.dto.auth;
+
+import java.util.UUID;
+
+public record ConfirmRegistrationRequest(
+    UUID userId,
+    String token
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapper.java
@@ -1,0 +1,28 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
+import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
+
+@Component
+public class AuthWebMapper {
+    public ConfirmRegistration toDomain(ConfirmRegistrationRequest request) {
+        if (request == null) return null;
+
+        return new ConfirmRegistration(
+            request.userId(),
+            request.token()
+        );
+    }
+
+    public AuthResponse toResponse(TokenPair tokenPair) {
+        if (tokenPair == null) return null;
+
+        return new AuthResponse(
+            tokenPair.accessToken(),
+            tokenPair.refreshToken()
+        );
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
@@ -9,22 +9,29 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
+import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
 import ru.jerael.booktracker.backend.web.config.WebProperties;
+import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
+import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import ru.jerael.booktracker.backend.web.mapper.AuthWebMapper;
 import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
 import tools.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @WebMvcTest(AuthController.class)
-@Import(UserWebMapper.class)
+@Import({UserWebMapper.class, AuthWebMapper.class})
 class AuthControllerTest {
 
     @Autowired
@@ -39,10 +46,16 @@ class AuthControllerTest {
     @MockitoBean
     private CreateUserUseCase createUserUseCase;
 
+    @MockitoBean
+    private ConfirmRegistrationUseCase confirmRegistrationUseCase;
+
     private final String email = "test@example.com";
     private final String password = "Password123!";
     private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+    private final String token = "123456";
+    private final String accessToken = "access token";
+    private final String refreshToken = "refresh token";
 
     @Test
     void register_ShouldReturnCreatedUser() {
@@ -80,5 +93,25 @@ class AuthControllerTest {
             .hasStatus(HttpStatus.CONFLICT)
             .bodyJson()
             .extractingPath("$.detail").asString().contains(existingEmail);
+    }
+
+    @Test
+    void confirmRegistration_ShouldReturnTokens_WhenRequestIsValid() {
+        ConfirmRegistrationRequest request = new ConfirmRegistrationRequest(userId, token);
+        TokenPair tokenPair = new TokenPair(accessToken, refreshToken);
+        when(confirmRegistrationUseCase.execute(any(ConfirmRegistration.class))).thenReturn(tokenPair);
+
+        assertThat(
+            mockMvcTester.post().uri("/api/v1/auth/confirm-registration")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .hasStatus(HttpStatus.OK)
+            .bodyJson()
+            .convertTo(AuthResponse.class)
+            .satisfies(response -> {
+                assertEquals(accessToken, response.accessToken());
+                assertEquals(refreshToken, response.refreshToken());
+            });
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapperTest.java
@@ -1,0 +1,38 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
+import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthWebMapperTest {
+    private final AuthWebMapper authWebMapper = new AuthWebMapper();
+
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final String token = "123456";
+    private final String accessToken = "access token";
+    private final String refreshToken = "refresh token";
+
+    @Test
+    void toDomain() {
+        ConfirmRegistrationRequest request = new ConfirmRegistrationRequest(userId, token);
+
+        ConfirmRegistration domain = authWebMapper.toDomain(request);
+
+        assertEquals(userId, domain.userId());
+        assertEquals(token, domain.token());
+    }
+
+    @Test
+    void toResponse() {
+        TokenPair tokenPair = new TokenPair(accessToken, refreshToken);
+
+        AuthResponse response = authWebMapper.toResponse(tokenPair);
+
+        assertEquals(accessToken, response.accessToken());
+        assertEquals(refreshToken, response.refreshToken());
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Added `ConfirmRegistrationRequest` and `AuthResponse` dtos.
- Added `AuthWebMapper` for mapping `ConfirmRegistrationRequest` -> `ConfirmRegistration` and `TokenPair` -> `AuthResponse`.
- Added `POST /auth/confirm-registration` endpoint in `AuthController`.

Tests:
- Added tests for `AuthWebMapper` and `/auth/confirm-registration` endpoint in `AuthController`.

### Related tickets

Closes #72

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
