### PR TITLE
feat: implement login validation

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
@@ -1,18 +1,24 @@
 package ru.jerael.booktracker.backend.application.validator;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
 import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
 import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 @Component
+@RequiredArgsConstructor
 public class AuthValidatorImpl implements AuthValidator {
+    private final FieldValidator fieldValidator;
+
     @Override
     public void validateRegistrationConfirmation(ConfirmRegistration data) {
         List<ValidationError> errors = new ArrayList<>();
@@ -36,6 +42,16 @@ public class AuthValidatorImpl implements AuthValidator {
             }
         }
 
+        if (!errors.isEmpty()) {
+            throw new ValidationException(errors);
+        }
+    }
+
+    @Override
+    public void validateLogin(UserLogin data) {
+        List<ValidationError> errors = new ArrayList<>();
+        errors.addAll(fieldValidator.validateEmail(data.email()));
+        errors.addAll(fieldValidator.validatePassword(data.password()));
         if (!errors.isEmpty()) {
             throw new ValidationException(errors);
         }

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImpl.java
@@ -1,0 +1,72 @@
+package ru.jerael.booktracker.backend.application.validator;
+
+import org.apache.commons.validator.routines.EmailValidator;
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.constant.UserRules;
+import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
+import ru.jerael.booktracker.backend.domain.exception.factory.EmailValidationErrorFactory;
+import ru.jerael.booktracker.backend.domain.exception.factory.PasswordValidationErrorFactory;
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class FieldValidatorImpl implements FieldValidator {
+    @Override
+    public List<ValidationError> validateEmail(String email) {
+        List<ValidationError> errors = new ArrayList<>();
+        if (email == null || email.isBlank()) {
+            errors.add(CommonValidationErrorFactory.emptyField("email"));
+        } else {
+            if (email.length() > UserRules.EMAIL_MAX_LENGTH) {
+                errors.add(CommonValidationErrorFactory.fieldTooLong("email", UserRules.EMAIL_MAX_LENGTH));
+            }
+            if (!EmailValidator.getInstance().isValid(email)) {
+                errors.add(EmailValidationErrorFactory.invalidFormat());
+            }
+        }
+        return errors;
+    }
+
+    @Override
+    public List<ValidationError> validatePassword(String password) {
+        List<ValidationError> errors = new ArrayList<>();
+        if (password == null || password.isBlank()) {
+            errors.add(CommonValidationErrorFactory.emptyField("password"));
+        } else {
+            if (password.length() < UserRules.MIN_PASSWORD_LENGTH) {
+                errors.add(CommonValidationErrorFactory.fieldTooShort("password", UserRules.MIN_PASSWORD_LENGTH));
+            }
+            if (password.chars().noneMatch(Character::isLowerCase)) {
+                errors.add(PasswordValidationErrorFactory.needsLowercase());
+            }
+            if (password.chars().noneMatch(Character::isUpperCase)) {
+                errors.add(PasswordValidationErrorFactory.needsUppercase());
+            }
+            if (password.chars().noneMatch(Character::isDigit)) {
+                errors.add(PasswordValidationErrorFactory.needsDigit());
+            }
+            if (password.chars().noneMatch(c -> UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS.contains((char) c))) {
+                errors.add(PasswordValidationErrorFactory.needsSpecialChar(UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS));
+            }
+
+            Set<Character> forbiddenChars = password.chars()
+                .filter(c -> !Character.isLowerCase(c) &&
+                    !Character.isUpperCase(c) &&
+                    !Character.isDigit(c) &&
+                    !UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS.contains((char) c)
+                )
+                .mapToObj(c -> (char) c)
+                .collect(Collectors.toSet());
+
+            if (!forbiddenChars.isEmpty()) {
+                errors.add(PasswordValidationErrorFactory.forbiddenChar(forbiddenChars,
+                    UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS));
+            }
+        }
+        return errors;
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/UserValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/UserValidatorImpl.java
@@ -1,82 +1,27 @@
 package ru.jerael.booktracker.backend.application.validator;
 
-import org.apache.commons.validator.routines.EmailValidator;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import ru.jerael.booktracker.backend.domain.constant.UserRules;
 import ru.jerael.booktracker.backend.domain.exception.ValidationException;
-import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
-import ru.jerael.booktracker.backend.domain.exception.factory.EmailValidationErrorFactory;
-import ru.jerael.booktracker.backend.domain.exception.factory.PasswordValidationErrorFactory;
 import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
 import ru.jerael.booktracker.backend.domain.validator.UserValidator;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class UserValidatorImpl implements UserValidator {
+    private final FieldValidator fieldValidator;
+
     @Override
     public void validateCreation(UserCreation data) {
         List<ValidationError> errors = new ArrayList<>();
-        errors.addAll(validateEmail(data.email()));
-        errors.addAll(validatePassword(data.password()));
+        errors.addAll(fieldValidator.validateEmail(data.email()));
+        errors.addAll(fieldValidator.validatePassword(data.password()));
         if (!errors.isEmpty()) {
             throw new ValidationException(errors);
         }
-    }
-
-    private List<ValidationError> validateEmail(String email) {
-        List<ValidationError> errors = new ArrayList<>();
-        if (email == null || email.isBlank()) {
-            errors.add(CommonValidationErrorFactory.emptyField("email"));
-        } else {
-            if (email.length() > UserRules.EMAIL_MAX_LENGTH) {
-                errors.add(CommonValidationErrorFactory.fieldTooLong("email", UserRules.EMAIL_MAX_LENGTH));
-            }
-            if (!EmailValidator.getInstance().isValid(email)) {
-                errors.add(EmailValidationErrorFactory.invalidFormat());
-            }
-        }
-        return errors;
-    }
-
-    private List<ValidationError> validatePassword(String password) {
-        List<ValidationError> errors = new ArrayList<>();
-        if (password == null || password.isBlank()) {
-            errors.add(CommonValidationErrorFactory.emptyField("password"));
-        } else {
-            if (password.length() < UserRules.MIN_PASSWORD_LENGTH) {
-                errors.add(CommonValidationErrorFactory.fieldTooShort("password", UserRules.MIN_PASSWORD_LENGTH));
-            }
-            if (password.chars().noneMatch(Character::isLowerCase)) {
-                errors.add(PasswordValidationErrorFactory.needsLowercase());
-            }
-            if (password.chars().noneMatch(Character::isUpperCase)) {
-                errors.add(PasswordValidationErrorFactory.needsUppercase());
-            }
-            if (password.chars().noneMatch(Character::isDigit)) {
-                errors.add(PasswordValidationErrorFactory.needsDigit());
-            }
-            if (password.chars().noneMatch(c -> UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS.contains((char) c))) {
-                errors.add(PasswordValidationErrorFactory.needsSpecialChar(UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS));
-            }
-
-            Set<Character> forbiddenChars = password.chars()
-                .filter(c -> !Character.isLowerCase(c) &&
-                    !Character.isUpperCase(c) &&
-                    !Character.isDigit(c) &&
-                    !UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS.contains((char) c)
-                )
-                .mapToObj(c -> (char) c)
-                .collect(Collectors.toSet());
-
-            if (!forbiddenChars.isEmpty()) {
-                errors.add(PasswordValidationErrorFactory.forbiddenChar(forbiddenChars,
-                    UserRules.PASSWORD_ALLOWED_SPECIAL_CHARS));
-            }
-        }
-        return errors;
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/UserLogin.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/UserLogin.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+public record UserLogin(
+    String email,
+    String password
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
@@ -1,7 +1,10 @@
 package ru.jerael.booktracker.backend.domain.validator;
 
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 
 public interface AuthValidator {
     void validateRegistrationConfirmation(ConfirmRegistration data);
+
+    void validateLogin(UserLogin data);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/FieldValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/FieldValidator.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.domain.validator;
+
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import java.util.List;
+
+public interface FieldValidator {
+    List<ValidationError> validateEmail(String email);
+
+    List<ValidationError> validatePassword(String password);
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
@@ -6,13 +6,15 @@ import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.code.CommonValidationErrorCode;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AuthValidatorImplTest {
-    private final AuthValidator authValidator = new AuthValidatorImpl();
+    private final FieldValidator fieldValidator = new FieldValidatorImpl();
+    private final AuthValidator authValidator = new AuthValidatorImpl(fieldValidator);
 
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
 

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImplTest.java
@@ -1,0 +1,150 @@
+package ru.jerael.booktracker.backend.application.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.domain.constant.UserRules;
+import ru.jerael.booktracker.backend.domain.exception.code.CommonValidationErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.code.EmailErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.code.PasswordErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FieldValidatorImplTest {
+    private final FieldValidator fieldValidator = new FieldValidatorImpl();
+
+    @Test
+    void validateEmail_WhenValid_ShouldReturnEmptyList() {
+        String email = "test@example.com";
+
+        List<ValidationError> errors = fieldValidator.validateEmail(email);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void validateEmail_WhenEmailIsEmpty_ShouldReturnEmptyFieldError() {
+        String email = "";
+
+        List<ValidationError> errors = fieldValidator.validateEmail(email);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(CommonValidationErrorCode.FIELD_CANNOT_BE_EMPTY.name());
+    }
+
+    @Test
+    void validateEmail_WhenEmailTooLong_ShouldReturnTooLongError() {
+        String email = "a".repeat(UserRules.EMAIL_MAX_LENGTH + 1);
+
+        List<ValidationError> errors = fieldValidator.validateEmail(email);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(CommonValidationErrorCode.FIELD_TOO_LONG.name());
+
+        assertThat(errors.get(0).params().get("max"));
+    }
+
+    @Test
+    void validateEmail_WhenFormatIsInvalid_ShouldReturnInvalidFormatError() {
+        String email = "invalid email";
+
+        List<ValidationError> errors = fieldValidator.validateEmail(email);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(EmailErrorCode.INVALID_FORMAT.name());
+    }
+
+    @Test
+    void validatePassword_WhenValid_ShouldReturnEmptyList() {
+        String password = "Password123!";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void validatePassword_WhenPasswordIsEmpty_ShouldReturnEmptyFieldError() {
+        String password = "";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(CommonValidationErrorCode.FIELD_CANNOT_BE_EMPTY.name());
+    }
+
+    @Test
+    void validatePassword_WhenPasswordTooShort_ShouldReturnTooShortError() {
+        String password = "aaa";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(CommonValidationErrorCode.FIELD_TOO_SHORT.name());
+
+        assertThat(errors.get(0).params().get("max"));
+    }
+
+    @Test
+    void validatePassword_WhenLowercaseCharDoesNotExists_ShouldReturnNeedsLowercaseError() {
+        String password = "PASSWORD123!";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(PasswordErrorCode.NEEDS_LOWERCASE.name());
+    }
+
+    @Test
+    void validatePassword_WhenUppercaseCharDoesNotExists_ShouldReturnNeedsUppercaseError() {
+        String password = "password123!";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(PasswordErrorCode.NEEDS_UPPERCASE.name());
+    }
+
+    @Test
+    void validatePassword_WhenDigitDoesNotExists_ShouldReturnNeedsDigitError() {
+        String password = "Password!";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(PasswordErrorCode.NEEDS_DIGIT.name());
+    }
+
+    @Test
+    void validatePassword_WhenSpecialCharDoesNotExists_ShouldReturnNeedsSpecialCharError() {
+        String password = "Password123";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(PasswordErrorCode.NEEDS_SPECIAL_CHAR.name());
+    }
+
+    @Test
+    void validatePassword_WhenForbiddenCharExists_ShouldReturnForbiddenCharError() {
+        String password = "Password 123!";
+
+        List<ValidationError> errors = fieldValidator.validatePassword(password);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(PasswordErrorCode.FORBIDDEN_CHAR.name());
+
+        assertNotNull(errors.get(0).params().get("forbidden"));
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/UserValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/UserValidatorImplTest.java
@@ -1,18 +1,17 @@
 package ru.jerael.booktracker.backend.application.validator;
 
 import org.junit.jupiter.api.Test;
-import ru.jerael.booktracker.backend.domain.constant.UserRules;
 import ru.jerael.booktracker.backend.domain.exception.ValidationException;
-import ru.jerael.booktracker.backend.domain.exception.code.CommonValidationErrorCode;
-import ru.jerael.booktracker.backend.domain.exception.code.EmailErrorCode;
-import ru.jerael.booktracker.backend.domain.exception.code.PasswordErrorCode;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
+import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
 import ru.jerael.booktracker.backend.domain.validator.UserValidator;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserValidatorImplTest {
-    private final UserValidator userValidator = new UserValidatorImpl();
+    private final FieldValidator fieldValidator = new FieldValidatorImpl();
+    private final UserValidator userValidator = new UserValidatorImpl(fieldValidator);
 
     @Test
     void validateCreation_WhenValidDataProvided_ShouldPassValidationWithoutErrors() {
@@ -31,131 +30,5 @@ class UserValidatorImplTest {
         assertThat(exception.getErrors()).hasSizeGreaterThan(1);
         assertThat(exception.getErrors()).anyMatch(e -> e.field().equals("email"));
         assertThat(exception.getErrors()).anyMatch(e -> e.field().equals("password"));
-    }
-
-    @Test
-    void validateEmail_WhenEmailIsEmpty_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("", "Password123!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(CommonValidationErrorCode.FIELD_CANNOT_BE_EMPTY.name());
-    }
-
-    @Test
-    void validateEmail_WhenEmailTooLong_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("a".repeat(UserRules.EMAIL_MAX_LENGTH + 1), "Password123!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(CommonValidationErrorCode.FIELD_TOO_LONG.name());
-
-        assertThat(exception.getErrors().get(0).params().get("max"));
-    }
-
-    @Test
-    void validateEmail_WhenFormatIsInvalid_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("invalid email", "Password123!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(EmailErrorCode.INVALID_FORMAT.name());
-    }
-
-    @Test
-    void validatePassword_WhenPasswordIsEmpty_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(CommonValidationErrorCode.FIELD_CANNOT_BE_EMPTY.name());
-    }
-
-    @Test
-    void validatePassword_WhenPasswordTooShort_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "aaa");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(CommonValidationErrorCode.FIELD_TOO_SHORT.name());
-
-        assertThat(exception.getErrors().get(0).params().get("max"));
-    }
-
-    @Test
-    void validatePassword_WhenLowercaseCharDoesNotExists_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "PASSWORD123!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(PasswordErrorCode.NEEDS_LOWERCASE.name());
-    }
-
-    @Test
-    void validatePassword_WhenUppercaseCharDoesNotExists_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "password123!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(PasswordErrorCode.NEEDS_UPPERCASE.name());
-    }
-
-    @Test
-    void validatePassword_WhenDigitDoesNotExists_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "Password!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(PasswordErrorCode.NEEDS_DIGIT.name());
-    }
-
-    @Test
-    void validatePassword_WhenSpecialCharDoesNotExists_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "Password123");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(PasswordErrorCode.NEEDS_SPECIAL_CHAR.name());
-    }
-
-    @Test
-    void validatePassword_WhenForbiddenCharExists_ShouldThrowValidationException() {
-        UserCreation data = new UserCreation("test@example.com", "Password 123!");
-
-        ValidationException exception =
-            assertThrows(ValidationException.class, () -> userValidator.validateCreation(data));
-
-        assertThat(exception.getErrors())
-            .extracting("code")
-            .contains(PasswordErrorCode.FORBIDDEN_CHAR.name());
-
-        assertNotNull(exception.getErrors().get(0).params().get("forbidden"));
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Added `UserLogin` domain model.
- Extracted reusable `validateEmail` and `validatePassword` methods form `UserValidatorImpl` to `FieldValidatorImpl`.
- Added `validateLogin` in `AuthValidator`.

Tests:
- Added tests for `FieldValidatorImpl`.
- Updated tests for `AuthValidatorImpl` and `UserValidatorImpl`.

### Related tickets

Part of #85 

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
