### PR TITLE
refactor: unify identity token generation

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
 import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
@@ -24,10 +25,10 @@ public class AuthTokenServiceImpl implements AuthTokenService {
     @Transactional
     public TokenPair issueTokens(UUID userId) {
         Map<String, Object> claims = Map.of("sub", userId);
-        String accessToken = identityTokenProvider.generateAccessToken(claims);
-        GeneratedToken refreshToken = identityTokenProvider.generateRefreshToken();
+        GeneratedToken accessToken = identityTokenProvider.generateToken(claims, IdentityTokenType.ACCESS);
+        GeneratedToken refreshToken = identityTokenProvider.generateToken(claims, IdentityTokenType.REFRESH);
         String hash = passwordHasher.hash(refreshToken.value());
         refreshTokenRepository.save(new RefreshToken(null, userId, hash, refreshToken.expiresAt()));
-        return new TokenPair(accessToken, refreshToken.value());
+        return new TokenPair(accessToken.value(), refreshToken.value());
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
@@ -11,11 +11,12 @@ import ru.jerael.booktracker.backend.data.exception.factory.JwtProviderException
 import ru.jerael.booktracker.backend.data.service.token.config.JwtProperties;
 import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
 import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -24,21 +25,18 @@ public class JwtProvider implements IdentityTokenProvider {
     private final JWSAlgorithm jwsAlgorithm = JWSAlgorithm.HS256;
 
     @Override
-    public String generateAccessToken(Map<String, Object> claims) {
+    public GeneratedToken generateToken(Map<String, Object> claims, IdentityTokenType tokenType) {
         Instant now = Instant.now();
-        Instant expiresAt = now.plus(properties.getAccessExpiry());
+        Duration expiry =
+            tokenType == IdentityTokenType.ACCESS ? properties.getAccessExpiry() : properties.getRefreshExpiry();
+        Instant expiresAt = now.plus(expiry);
         JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
             .issuer(properties.getIssuer())
             .issueTime(Date.from(now))
             .expirationTime(Date.from(expiresAt));
         claims.forEach(builder::claim);
-        return signJWT(builder.build());
-    }
-
-    @Override
-    public GeneratedToken generateRefreshToken() {
-        String value = UUID.randomUUID().toString();
-        Instant expiresAt = Instant.now().plus(properties.getRefreshExpiry());
+        builder.claim("type", tokenType.name());
+        String value = signJWT(builder.build());
         return new GeneratedToken(value, expiresAt);
     }
 

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/IdentityTokenType.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/IdentityTokenType.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+public enum IdentityTokenType {
+    ACCESS,
+    REFRESH
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
@@ -1,12 +1,11 @@
 package ru.jerael.booktracker.backend.domain.service.token;
 
 import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import java.util.Map;
 
 public interface IdentityTokenProvider {
-    String generateAccessToken(Map<String, Object> claims);
-
-    GeneratedToken generateRefreshToken();
+    GeneratedToken generateToken(Map<String, Object> claims, IdentityTokenType tokenType);
 
     Map<String, Object> extractClaims(String token);
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/service/AuthTokenServiceImplTest.java
@@ -9,15 +9,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
 import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
 import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,8 +50,10 @@ class AuthTokenServiceImplTest {
         String accessToken = "access token";
         String refreshToken = "refresh token";
         String hash = "refresh token hash";
-        when(identityTokenProvider.generateAccessToken(any())).thenReturn(accessToken);
-        when(identityTokenProvider.generateRefreshToken()).thenReturn(new GeneratedToken(refreshToken, expiresAt));
+        when(identityTokenProvider.generateToken(any(), eq(IdentityTokenType.ACCESS)))
+            .thenReturn(new GeneratedToken(accessToken, expiresAt));
+        when(identityTokenProvider.generateToken(any(), eq(IdentityTokenType.REFRESH)))
+            .thenReturn(new GeneratedToken(refreshToken, expiresAt));
         when(passwordHasher.hash(refreshToken)).thenReturn(hash);
 
         TokenPair result = service.issueTokens(userId);
@@ -56,9 +61,12 @@ class AuthTokenServiceImplTest {
         assertEquals(accessToken, result.accessToken());
         assertEquals(refreshToken, result.refreshToken());
 
-        verify(identityTokenProvider).generateAccessToken(claimsCaptor.capture());
-        Map<String, Object> capturedClaims = claimsCaptor.getValue();
-        assertEquals(userId, capturedClaims.get("sub"));
+        verify(identityTokenProvider).generateToken(claimsCaptor.capture(), eq(IdentityTokenType.ACCESS));
+        verify(identityTokenProvider).generateToken(claimsCaptor.capture(), eq(IdentityTokenType.REFRESH));
+
+        List<Map<String, Object>> capturedClaims = claimsCaptor.getAllValues();
+        assertEquals(userId, capturedClaims.get(0).get("sub"));
+        assertEquals(userId, capturedClaims.get(1).get("sub"));
 
         verify(passwordHasher).hash(refreshToken);
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
@@ -10,13 +10,17 @@ import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.service.token.config.JwtProperties;
 import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
 import ru.jerael.booktracker.backend.domain.model.auth.GeneratedToken;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
+import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JwtProviderTest {
     private final JwtProvider jwtProvider;
@@ -39,35 +43,47 @@ class JwtProviderTest {
     }
 
     @Test
-    void generateAccessToken_ShouldCreateValidSignedJwt() {
-        String token = jwtProvider.generateAccessToken(claims);
+    void generateToken_ShouldCreateValidSignedJwt() {
+        String token = jwtProvider.generateToken(claims, IdentityTokenType.ACCESS).value();
 
         assertThat(token).isNotBlank();
         assertEquals(3, token.split("\\.").length);
     }
 
     @Test
-    void generateRefreshToken_ShouldCreateValidUuidAndExpiry() {
-        GeneratedToken generatedToken = jwtProvider.generateRefreshToken();
+    void generateToken_WhenTypeIsAccess_ShouldSetAccessExpiry() {
+        Instant now = Instant.now();
+        Instant expectedExpiry = now.plus(accessExpiry);
 
-        assertThat(generatedToken.value()).isNotBlank();
-        assertNotNull(UUID.fromString(generatedToken.value()));
-        assertThat(generatedToken.expiresAt()).isAfter(Instant.now());
+        GeneratedToken generatedToken = jwtProvider.generateToken(claims, IdentityTokenType.ACCESS);
+
+        assertThat(generatedToken.expiresAt()).isCloseTo(expectedExpiry, within(1, ChronoUnit.SECONDS));
+    }
+
+    @Test
+    void generateToken_WhenTypeIsRefresh_ShouldSetRefreshExpiry() {
+        Instant now = Instant.now();
+        Instant expectedExpiry = now.plus(refreshExpiry);
+
+        GeneratedToken generatedToken = jwtProvider.generateToken(claims, IdentityTokenType.REFRESH);
+
+        assertThat(generatedToken.expiresAt()).isCloseTo(expectedExpiry, within(1, ChronoUnit.SECONDS));
     }
 
     @Test
     void extractClaims_WhenTokenIsValid_ShouldReturnCorrectClaims() {
-        String token = jwtProvider.generateAccessToken(claims);
+        GeneratedToken generatedToken = jwtProvider.generateToken(claims, IdentityTokenType.ACCESS);
 
-        Map<String, Object> result = jwtProvider.extractClaims(token);
+        Map<String, Object> result = jwtProvider.extractClaims(generatedToken.value());
 
         assertThat(result.get("sub")).isEqualTo(userId.toString());
         assertThat(result.get("iss")).isEqualTo(issuer);
+        assertThat(result.get("type")).isEqualTo(IdentityTokenType.ACCESS.name());
     }
 
     @Test
     void extractClaims_WhenSignatureIsInvalid_ShouldThrowException() {
-        String validToken = jwtProvider.generateAccessToken(claims);
+        String validToken = jwtProvider.generateToken(claims, IdentityTokenType.ACCESS).value();
         String invalidToken = validToken.substring(0, validToken.length() - 10);
 
         Throwable throwable =


### PR DESCRIPTION
### What does this PR do?

- Added `IdentityTokenType` enum in domain layer.
- Updated `IdentityTokenProvider` and its implementation `JwtProvider`.
- Updated `AuthServiceImpl`.

Tests:
- Updated tests for `JwtProvider` and `AuthServiceImpl`.

### Related tickets

Closes #90 

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
