### PR TITLE
feat: add RefreshTokenPayload model and validation

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
@@ -7,6 +7,7 @@ import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
 import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
 import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
@@ -52,6 +53,20 @@ public class AuthValidatorImpl implements AuthValidator {
         List<ValidationError> errors = new ArrayList<>();
         errors.addAll(fieldValidator.validateEmail(data.email()));
         errors.addAll(fieldValidator.validatePassword(data.password()));
+        if (!errors.isEmpty()) {
+            throw new ValidationException(errors);
+        }
+    }
+
+    @Override
+    public void validateRefreshTokenPayload(RefreshTokenPayload data) {
+        List<ValidationError> errors = new ArrayList<>();
+        String refreshToken = data.refreshToken();
+
+        if (refreshToken == null || refreshToken.isBlank()) {
+            errors.add(CommonValidationErrorFactory.emptyField("refreshToken"));
+        }
+
         if (!errors.isEmpty()) {
             throw new ValidationException(errors);
         }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/RefreshTokenPayload.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/RefreshTokenPayload.java
@@ -1,0 +1,3 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+public record RefreshTokenPayload(String refreshToken) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
@@ -1,10 +1,13 @@
 package ru.jerael.booktracker.backend.domain.validator;
 
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 
 public interface AuthValidator {
     void validateRegistrationConfirmation(ConfirmRegistration data);
 
     void validateLogin(UserLogin data);
+
+    void validateRefreshTokenPayload(RefreshTokenPayload data);
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
@@ -5,6 +5,7 @@ import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
 import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.code.CommonValidationErrorCode;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
 import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
 import java.util.UUID;
@@ -17,6 +18,7 @@ class AuthValidatorImplTest {
     private final AuthValidator authValidator = new AuthValidatorImpl(fieldValidator);
 
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
+    private final String refreshToken = "refresh token";
 
     @Test
     void validateRegistrationConfirmation_WhenValid_ShouldNotThrowException() {
@@ -64,5 +66,22 @@ class AuthValidatorImplTest {
             assertThrows(ValidationException.class, () -> authValidator.validateRegistrationConfirmation(data));
 
         assertThat(ex.getErrors()).anyMatch(e -> e.code().equals(CommonValidationErrorCode.FIELD_TOO_LONG.name()));
+    }
+
+    @Test
+    void validateRefreshTokenPayload_WhenValid_ShouldNotThrowException() {
+        RefreshTokenPayload data = new RefreshTokenPayload(refreshToken);
+
+        assertDoesNotThrow(() -> authValidator.validateRefreshTokenPayload(data));
+    }
+
+    @Test
+    void validateRefreshTokenPayload_WhenRefreshTokenIsBlank_ShouldThrowException() {
+        RefreshTokenPayload data = new RefreshTokenPayload("  ");
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> authValidator.validateRefreshTokenPayload(data));
+
+        assertThat(ex.getErrors()).anyMatch(e -> e.field().equals("refreshToken"));
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Added `RefreshTokenPayload` model in domain layer.
- Added `validateRefreshTokenPayload` method to `AuthValidator`.

Tests:
- Added tests for `validateRefreshTokenPayload` to `AuthValidatorImplTest`.

### Related tickets

Part of #89

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
