### PR TITLE
feat: implement refresh tokens use case

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImpl.java
@@ -1,0 +1,47 @@
+package ru.jerael.booktracker.backend.application.usecase.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
+import ru.jerael.booktracker.backend.domain.usecase.auth.RefreshTokensUseCase;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokensUseCaseImpl implements RefreshTokensUseCase {
+    private final AuthValidator authValidator;
+    private final IdentityTokenProvider identityTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordHasher passwordHasher;
+    private final AuthTokenService authTokenService;
+
+    @Override
+    public TokenPair execute(RefreshTokenPayload data) {
+        authValidator.validateRefreshTokenPayload(data);
+        String refreshToken = data.refreshToken();
+        Map<String, Object> claims = identityTokenProvider.extractClaims(refreshToken, IdentityTokenType.REFRESH);
+        String actualType = claims.get("type").toString();
+        if (!actualType.equals(IdentityTokenType.REFRESH.name())) {
+            throw UserExceptionFactory.invalidCredentials();
+        }
+        UUID userId = UUID.fromString(claims.get("sub").toString());
+        List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByUserId(userId);
+        RefreshToken foundRefreshToken = refreshTokens.stream()
+            .filter(token -> passwordHasher.verify(refreshToken, token.tokenHash()))
+            .findFirst()
+            .orElseThrow(UserExceptionFactory::invalidCredentials);
+        refreshTokenRepository.deleteById(foundRefreshToken.id());
+        return authTokenService.issueTokens(userId);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaRefreshTokenRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaRefreshTokenRepository.java
@@ -3,7 +3,10 @@ package ru.jerael.booktracker.backend.data.db.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface JpaRefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {}
+public interface JpaRefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+    List<RefreshTokenEntity> findAllByUserId(UUID userId);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/exception/code/JwtProviderErrorCode.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/exception/code/JwtProviderErrorCode.java
@@ -7,5 +7,6 @@ public enum JwtProviderErrorCode implements ErrorCode {
     INVALID_SIGNATURE,
     TOKEN_EXPIRED,
     TOKEN_MALFORMED,
-    INVALID_ISSUER
+    INVALID_ISSUER,
+    INVALID_TOKEN_TYPE
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/exception/factory/JwtProviderExceptionFactory.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/exception/factory/JwtProviderExceptionFactory.java
@@ -40,4 +40,11 @@ public class JwtProviderExceptionFactory {
             "Token issuer is invalid: " + issuer
         );
     }
+
+    public static UnauthenticatedException invalidTokenType(String expected, String actual) {
+        return new UnauthenticatedException(
+            JwtProviderErrorCode.INVALID_TOKEN_TYPE,
+            "Expected token type " + expected + " but got " + actual
+        );
+    }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapper.java
@@ -16,4 +16,15 @@ public class RefreshTokenDataMapper {
         entity.setExpiresAt(refreshToken.expiresAt());
         return entity;
     }
+
+    public RefreshToken toDomain(RefreshTokenEntity entity) {
+        if (entity == null) return null;
+
+        return new RefreshToken(
+            entity.getId(),
+            entity.getUserId(),
+            entity.getTokenHash(),
+            entity.getExpiresAt()
+        );
+    }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImpl.java
@@ -7,6 +7,8 @@ import ru.jerael.booktracker.backend.data.db.repository.JpaRefreshTokenRepositor
 import ru.jerael.booktracker.backend.data.mapper.RefreshTokenDataMapper;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
 import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import java.util.List;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,5 +20,11 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     public void save(RefreshToken refreshToken) {
         RefreshTokenEntity entity = refreshTokenDataMapper.toEntity(refreshToken);
         jpaRefreshTokenRepository.save(entity);
+    }
+
+    @Override
+    public List<RefreshToken> findAllByUserId(UUID userId) {
+        return jpaRefreshTokenRepository.findAllByUserId(userId).stream().map(refreshTokenDataMapper::toDomain)
+            .toList();
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImpl.java
@@ -27,4 +27,9 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
         return jpaRefreshTokenRepository.findAllByUserId(userId).stream().map(refreshTokenDataMapper::toDomain)
             .toList();
     }
+
+    @Override
+    public void deleteById(UUID id) {
+        jpaRefreshTokenRepository.deleteById(id);
+    }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
@@ -41,7 +41,7 @@ public class JwtProvider implements IdentityTokenProvider {
     }
 
     @Override
-    public Map<String, Object> extractClaims(String token) {
+    public Map<String, Object> extractClaims(String token, IdentityTokenType expectedType) {
         try {
             SignedJWT signedJWT = SignedJWT.parse(token);
             JWSVerifier jwsVerifier = new MACVerifier(properties.getSecret());
@@ -54,6 +54,10 @@ public class JwtProvider implements IdentityTokenProvider {
             }
             if (!jwtClaimsSet.getIssuer().equals(properties.getIssuer())) {
                 throw JwtProviderExceptionFactory.invalidIssuer(jwtClaimsSet.getIssuer());
+            }
+            String actualType = jwtClaimsSet.getClaim("type").toString();
+            if (actualType == null || actualType.isBlank() || !actualType.equals(expectedType.name())) {
+                throw JwtProviderExceptionFactory.invalidTokenType(expectedType.name(), actualType);
             }
             return jwtClaimsSet.getClaims();
         } catch (JOSEException e) {

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ public interface RefreshTokenRepository {
     void save(RefreshToken refreshToken);
 
     List<RefreshToken> findAllByUserId(UUID userId);
+
+    void deleteById(UUID id);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/RefreshTokenRepository.java
@@ -1,7 +1,11 @@
 package ru.jerael.booktracker.backend.domain.repository;
 
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import java.util.List;
+import java.util.UUID;
 
 public interface RefreshTokenRepository {
     void save(RefreshToken refreshToken);
+
+    List<RefreshToken> findAllByUserId(UUID userId);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
@@ -7,5 +7,5 @@ import java.util.Map;
 public interface IdentityTokenProvider {
     GeneratedToken generateToken(Map<String, Object> claims, IdentityTokenType tokenType);
 
-    Map<String, Object> extractClaims(String token);
+    Map<String, Object> extractClaims(String token, IdentityTokenType expectedType);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/auth/RefreshTokensUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/auth/RefreshTokensUseCase.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.usecase.auth;
+
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+
+public interface RefreshTokensUseCase {
+    TokenPair execute(RefreshTokenPayload data);
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImplTest.java
@@ -1,0 +1,100 @@
+package ru.jerael.booktracker.backend.application.usecase.auth;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
+import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
+import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokensUseCaseImplTest {
+
+    @Mock
+    private AuthValidator authValidator;
+
+    @Mock
+    private IdentityTokenProvider identityTokenProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private PasswordHasher passwordHasher;
+
+    @Mock
+    private AuthTokenService authTokenService;
+
+    @InjectMocks
+    private RefreshTokensUseCaseImpl useCase;
+
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final String refreshToken = "user.jwt.token";
+    private final RefreshTokenPayload data = new RefreshTokenPayload(refreshToken);
+    private final Map<String, Object> claims = Map.of(
+        "sub", userId.toString(),
+        "type", IdentityTokenType.REFRESH.name()
+    );
+    private final UUID tokenId = UUID.fromString("b4e4e673-b851-4c0e-8626-a073941a018b");
+
+    @Test
+    void execute_ShouldDeleteExistingTokenAndInsertNewAndReturnNewTokenPair() {
+        RefreshToken token = new RefreshToken(tokenId, userId, "token hash", Instant.now().plusSeconds(100));
+        TokenPair tokenPair = new TokenPair("access token", "refresh token");
+        when(identityTokenProvider.extractClaims(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
+        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of(token));
+        when(passwordHasher.verify(refreshToken, "token hash")).thenReturn(true);
+        when(authTokenService.issueTokens(userId)).thenReturn(tokenPair);
+
+        TokenPair result = useCase.execute(data);
+
+        assertEquals(tokenPair, result);
+        verify(authValidator).validateRefreshTokenPayload(data);
+        verify(refreshTokenRepository).deleteById(tokenId);
+        verify(authTokenService).issueTokens(userId);
+    }
+
+    @Test
+    void execute_WhenTokenHashMismatched_ShouldThrowUnauthenticatedException() {
+        RefreshToken storedToken = new RefreshToken(tokenId, userId, "token hash 2", Instant.now());
+        when(identityTokenProvider.extractClaims(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
+        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of(storedToken));
+        when(passwordHasher.verify(refreshToken, "token hash 2")).thenReturn(false);
+
+        assertThrows(UnauthenticatedException.class, () -> useCase.execute(data));
+
+        verify(refreshTokenRepository, never()).deleteById(any());
+        verifyNoInteractions(authTokenService);
+    }
+
+    @Test
+    void execute_WhenTokenTypeIsWrong_ShouldThrowUnauthenticatedException() {
+        when(identityTokenProvider.extractClaims(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
+
+        assertThrows(UnauthenticatedException.class, () -> useCase.execute(data));
+    }
+
+    @Test
+    void execute_WhenNotFoundTokensForUser_ShouldThrowUnauthenticatedException() {
+        when(identityTokenProvider.extractClaims(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
+        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of());
+
+        assertThrows(UnauthenticatedException.class, () -> useCase.execute(data));
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapperTest.java
@@ -26,4 +26,20 @@ class RefreshTokenDataMapperTest {
         assertEquals(tokenHash, entity.getTokenHash());
         assertEquals(expiresAt, entity.getExpiresAt());
     }
+
+    @Test
+    void toDomain() {
+        RefreshTokenEntity entity = new RefreshTokenEntity();
+        entity.setId(id);
+        entity.setUserId(userId);
+        entity.setTokenHash(tokenHash);
+        entity.setExpiresAt(expiresAt);
+
+        RefreshToken domain = refreshTokenDataMapper.toDomain(entity);
+
+        assertEquals(id, domain.id());
+        assertEquals(userId, domain.userId());
+        assertEquals(tokenHash, domain.tokenHash());
+        assertEquals(expiresAt, domain.expiresAt());
+    }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
@@ -5,12 +5,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.data.db.repository.JpaRefreshTokenRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
 import ru.jerael.booktracker.backend.data.mapper.RefreshTokenDataMapper;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 @DataJpaTest
@@ -22,6 +25,9 @@ class RefreshTokenRepositoryImplTest {
 
     @Autowired
     private JpaRefreshTokenRepository jpaRefreshTokenRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
 
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String tokenHash = "token hash";
@@ -41,5 +47,35 @@ class RefreshTokenRepositoryImplTest {
         assertEquals(userId, entity.getUserId());
         assertEquals(tokenHash, entity.getTokenHash());
         assertEquals(expiresAt, entity.getExpiresAt());
+    }
+
+    @Test
+    void findAllByUserId() {
+        UserEntity userEntity = new UserEntity();
+        userEntity.setEmail(userId + "@example.com");
+        userEntity.setPasswordHash("password hash");
+        userEntity.setVerified(true);
+        userEntity.setCreatedAt(Instant.now());
+        UUID userId2 = jpaUserRepository.save(userEntity).getId();
+
+        saveEntity(userId, tokenHash);
+        saveEntity(userId2, "token hash 2");
+        saveEntity(userId2, "token hash 3");
+
+        List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByUserId(userId2);
+
+        assertEquals(2, refreshTokens.size());
+        assertThat(refreshTokens).allSatisfy(refreshToken -> {
+            assertEquals(userId2, refreshToken.userId());
+            assertThat(refreshToken.tokenHash()).startsWith("token hash ");
+        });
+    }
+
+    private void saveEntity(UUID userId, String hash) {
+        RefreshTokenEntity entity = new RefreshTokenEntity();
+        entity.setUserId(userId);
+        entity.setTokenHash(hash);
+        entity.setExpiresAt(expiresAt);
+        jpaRefreshTokenRepository.save(entity);
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 @DataJpaTest
 @Import({RefreshTokenRepositoryImpl.class, RefreshTokenDataMapper.class})
@@ -71,11 +71,29 @@ class RefreshTokenRepositoryImplTest {
         });
     }
 
-    private void saveEntity(UUID userId, String hash) {
+    @Test
+    void deleteById() {
+        UserEntity userEntity = new UserEntity();
+        userEntity.setEmail(userId + "@example.com");
+        userEntity.setPasswordHash("password hash");
+        userEntity.setVerified(true);
+        userEntity.setCreatedAt(Instant.now());
+        UUID userId = jpaUserRepository.save(userEntity).getId();
+
+        RefreshTokenEntity savedEntity = saveEntity(userId, tokenHash);
+
+        assertTrue(jpaRefreshTokenRepository.existsById(savedEntity.getId()));
+
+        refreshTokenRepository.deleteById(savedEntity.getId());
+
+        assertFalse(jpaRefreshTokenRepository.existsById(savedEntity.getId()));
+    }
+
+    private RefreshTokenEntity saveEntity(UUID userId, String hash) {
         RefreshTokenEntity entity = new RefreshTokenEntity();
         entity.setUserId(userId);
         entity.setTokenHash(hash);
         entity.setExpiresAt(expiresAt);
-        jpaRefreshTokenRepository.save(entity);
+        return jpaRefreshTokenRepository.save(entity);
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
@@ -74,7 +74,7 @@ class JwtProviderTest {
     void extractClaims_WhenTokenIsValid_ShouldReturnCorrectClaims() {
         GeneratedToken generatedToken = jwtProvider.generateToken(claims, IdentityTokenType.ACCESS);
 
-        Map<String, Object> result = jwtProvider.extractClaims(generatedToken.value());
+        Map<String, Object> result = jwtProvider.extractClaims(generatedToken.value(), IdentityTokenType.ACCESS);
 
         assertThat(result.get("sub")).isEqualTo(userId.toString());
         assertThat(result.get("iss")).isEqualTo(issuer);
@@ -86,8 +86,8 @@ class JwtProviderTest {
         String validToken = jwtProvider.generateToken(claims, IdentityTokenType.ACCESS).value();
         String invalidToken = validToken.substring(0, validToken.length() - 10);
 
-        Throwable throwable =
-            assertThrows(UnauthenticatedException.class, () -> jwtProvider.extractClaims(invalidToken));
+        Throwable throwable = assertThrows(UnauthenticatedException.class,
+            () -> jwtProvider.extractClaims(invalidToken, IdentityTokenType.ACCESS));
 
         assertThat(throwable.getMessage()).contains("Token signature is invalid");
     }
@@ -106,8 +106,8 @@ class JwtProviderTest {
 
         String expiredToken = signedJWT.serialize();
 
-        Throwable throwable =
-            assertThrows(UnauthenticatedException.class, () -> jwtProvider.extractClaims(expiredToken));
+        Throwable throwable = assertThrows(UnauthenticatedException.class,
+            () -> jwtProvider.extractClaims(expiredToken, IdentityTokenType.ACCESS));
 
         assertThat(throwable.getMessage()).contains("Token has expired");
     }
@@ -130,7 +130,8 @@ class JwtProviderTest {
         String badToken = signedJWT.serialize();
 
         Throwable throwable =
-            assertThrows(UnauthenticatedException.class, () -> jwtProvider.extractClaims(badToken));
+            assertThrows(UnauthenticatedException.class,
+                () -> jwtProvider.extractClaims(badToken, IdentityTokenType.ACCESS));
 
         assertThat(throwable.getMessage()).contains("Token issuer is invalid: " + wrongIssuer);
     }
@@ -140,7 +141,8 @@ class JwtProviderTest {
         String malformedToken = "not a jwt string";
 
         Throwable throwable =
-            assertThrows(UnauthenticatedException.class, () -> jwtProvider.extractClaims(malformedToken));
+            assertThrows(UnauthenticatedException.class,
+                () -> jwtProvider.extractClaims(malformedToken, IdentityTokenType.ACCESS));
 
         assertThat(throwable.getMessage()).contains("Token is invalid or corrupted");
     }


### PR DESCRIPTION
### What does this PR do?

- Added mapper `RefreshTokenEntity` -> `RefreshToken` to `RefreshTokenDataMapper`.
- Added token type check to `JwtProvider.extractClaims`.
- Added `findAllByUserId` and `deleteById` methods to `RefreshTokenRepository`.
- Implemented `RefreshTokensUseCase`.

Tests:
- Added tests for `RefreshTokensUseCaseImpl`.
- Updated tests for `RefreshTokenDataMapper`, `JwtProvider`, `RefreshTokenRepositoryImpl`.

### Related tickets

Part of #89

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
