### PR TITLE
feat: implement refresh tokens endpoint

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
@@ -7,16 +7,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
 import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.auth.LoginUserUseCase;
+import ru.jerael.booktracker.backend.domain.usecase.auth.RefreshTokensUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
 import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
 import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
 import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
+import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
 import ru.jerael.booktracker.backend.web.mapper.AuthWebMapper;
@@ -32,6 +35,7 @@ public class AuthController {
     private final CreateUserUseCase createUserUseCase;
     private final ConfirmRegistrationUseCase confirmRegistrationUseCase;
     private final LoginUserUseCase loginUserUseCase;
+    private final RefreshTokensUseCase refreshTokensUseCase;
 
     @Operation(summary = "Register new user")
     @PostMapping("/register")
@@ -55,6 +59,14 @@ public class AuthController {
     public AuthResponse login(@Valid @RequestBody LoginRequest request) {
         UserLogin data = authWebMapper.toDomain(request);
         TokenPair tokenPair = loginUserUseCase.execute(data);
+        return authWebMapper.toResponse(tokenPair);
+    }
+
+    @Operation(summary = "Refresh tokens")
+    @PostMapping("/refresh")
+    public AuthResponse refresh(@Valid @RequestBody RefreshTokensRequest request) {
+        RefreshTokenPayload data = authWebMapper.toDomain(request);
+        TokenPair tokenPair = refreshTokensUseCase.execute(data);
         return authWebMapper.toResponse(tokenPair);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/RefreshTokensRequest.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/RefreshTokensRequest.java
@@ -1,0 +1,3 @@
+package ru.jerael.booktracker.backend.web.dto.auth;
+
+public record RefreshTokensRequest(String refreshToken) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapper.java
@@ -2,11 +2,13 @@ package ru.jerael.booktracker.backend.web.mapper;
 
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
 import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
 import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
+import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
 
 @Component
 public class AuthWebMapper {
@@ -35,5 +37,11 @@ public class AuthWebMapper {
             request.email(),
             request.password()
         );
+    }
+
+    public RefreshTokenPayload toDomain(RefreshTokensRequest request) {
+        if (request == null) return null;
+
+        return new RefreshTokenPayload(request.refreshToken());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
@@ -10,17 +10,20 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
 import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.auth.LoginUserUseCase;
+import ru.jerael.booktracker.backend.domain.usecase.auth.RefreshTokensUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
 import ru.jerael.booktracker.backend.web.config.WebProperties;
 import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
 import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
 import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
+import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
 import ru.jerael.booktracker.backend.web.mapper.AuthWebMapper;
@@ -54,6 +57,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private LoginUserUseCase loginUserUseCase;
+
+    @MockitoBean
+    private RefreshTokensUseCase refreshTokensUseCase;
 
     private final String email = "test@example.com";
     private final String password = "Password123!";
@@ -129,6 +135,26 @@ class AuthControllerTest {
 
         assertThat(
             mockMvcTester.post().uri("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .hasStatus(HttpStatus.OK)
+            .bodyJson()
+            .convertTo(AuthResponse.class)
+            .satisfies(response -> {
+                assertEquals(accessToken, response.accessToken());
+                assertEquals(refreshToken, response.refreshToken());
+            });
+    }
+
+    @Test
+    void refresh_WhenRequestIsValid_ShouldReturnTokens() {
+        RefreshTokensRequest request = new RefreshTokensRequest(refreshToken);
+        TokenPair tokenPair = new TokenPair(accessToken, refreshToken);
+        when(refreshTokensUseCase.execute(any(RefreshTokenPayload.class))).thenReturn(tokenPair);
+
+        assertThat(
+            mockMvcTester.post().uri("/api/v1/auth/refresh")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapperTest.java
@@ -2,11 +2,13 @@ package ru.jerael.booktracker.backend.web.mapper;
 
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
 import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
 import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
+import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -48,5 +50,14 @@ class AuthWebMapperTest {
 
         assertEquals(email, domain.email());
         assertEquals(password, domain.password());
+    }
+
+    @Test
+    void toDomain_RefreshTokenPayload() {
+        RefreshTokensRequest request = new RefreshTokensRequest(refreshToken);
+
+        RefreshTokenPayload domain = authWebMapper.toDomain(request);
+
+        assertEquals(refreshToken, domain.refreshToken());
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Added `RefreshTokensRequest` dto.
- Added mapper `RefreshTokensRequest` -> `RefreshTokenPayload` to `AuthWebMapper`.
- Added `POST /auth/refresh` endpoint.

Tests:
- Added tests for `AuthWebMapper` and `/auth/refresh` endpoint in `AuthController`.

### Related tickets

Closes #89

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
