### PR TITLE
feat: add token encoding and decoding

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/service/token/JwtProvider.java
@@ -69,6 +69,42 @@ public class JwtProvider implements IdentityTokenProvider {
         }
     }
 
+    @Override
+    public String encode(Map<String, Object> claims) {
+        try {
+            JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                .issuer(properties.getIssuer())
+                .issueTime(new Date());
+            claims.forEach(builder::claim);
+            JWTClaimsSet jwtClaimsSet = builder.build();
+
+            JWSSigner jwsSigner = new MACSigner(properties.getSecret());
+            SignedJWT signedJWT = new SignedJWT(new JWSHeader(jwsAlgorithm), jwtClaimsSet);
+            signedJWT.sign(jwsSigner);
+            return signedJWT.serialize();
+        } catch (Exception e) {
+            throw JwtProviderExceptionFactory.signingFailed(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> decode(String token) {
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(token);
+            JWSVerifier jwsVerifier = new MACVerifier(properties.getSecret());
+            if (!signedJWT.verify(jwsVerifier)) {
+                throw JwtProviderExceptionFactory.invalidSignature();
+            }
+            return signedJWT.getJWTClaimsSet().getClaims();
+        } catch (JOSEException e) {
+            throw JwtProviderExceptionFactory.signingFailed(e.getMessage(), e);
+        } catch (UnauthenticatedException e) {
+            throw e;
+        } catch (Exception e) {
+            throw JwtProviderExceptionFactory.tokenMalformed(e.getMessage());
+        }
+    }
+
     private String signJWT(JWTClaimsSet jwtClaimsSet) {
         try {
             JWSSigner jwsSigner = new MACSigner(properties.getSecret());

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/IdentityTokenProvider.java
@@ -5,7 +5,13 @@ import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import java.util.Map;
 
 public interface IdentityTokenProvider {
+    @Deprecated
     GeneratedToken generateToken(Map<String, Object> claims, IdentityTokenType tokenType);
 
+    @Deprecated
     Map<String, Object> extractClaims(String token, IdentityTokenType expectedType);
+
+    String encode(Map<String, Object> claims);
+
+    Map<String, Object> decode(String token);
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/service/token/JwtProviderTest.java
@@ -27,11 +27,19 @@ class JwtProviderTest {
 
     private final String secret = "very-very-very-very-very-long-string";
     private final Duration accessExpiry = Duration.ofMinutes(10L);
+    private final long accessExpiresAt = Instant.now().plus(accessExpiry).toEpochMilli();
     private final Duration refreshExpiry = Duration.ofDays(30L);
+    private final long refreshExpiresAt = Instant.now().plus(refreshExpiry).toEpochMilli();
     private final String issuer = "issuer";
 
     private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final Map<String, Object> claims = Map.of("sub", userId);
+    private final Map<String, Object> claims2 = Map.of(
+        "userId", userId,
+        "issuer", issuer,
+        "type", IdentityTokenType.ACCESS,
+        "expiresAt", accessExpiresAt
+    );
 
     public JwtProviderTest() {
         JwtProperties properties = new JwtProperties();
@@ -143,6 +151,46 @@ class JwtProviderTest {
         Throwable throwable =
             assertThrows(UnauthenticatedException.class,
                 () -> jwtProvider.extractClaims(malformedToken, IdentityTokenType.ACCESS));
+
+        assertThat(throwable.getMessage()).contains("Token is invalid or corrupted");
+    }
+
+
+    @Test
+    void encode_ShouldCreateValidSignedJwt() {
+        String token = jwtProvider.encode(claims2);
+
+        assertThat(token).isNotBlank();
+        assertEquals(3, token.split("\\.").length);
+    }
+
+    @Test
+    void decode_WhenTokenIsValid_ShouldReturnCorrectClaims() {
+        String token = jwtProvider.encode(claims2);
+
+        Map<String, Object> result = jwtProvider.decode(token);
+
+        assertThat(result.get("userId")).isEqualTo(userId.toString());
+        assertThat(result.get("issuer")).isEqualTo(issuer);
+        assertThat(result.get("type")).isEqualTo(IdentityTokenType.ACCESS.name());
+        assertThat(result.get("expiresAt")).isEqualTo(accessExpiresAt);
+    }
+
+    @Test
+    void decode_WhenSignatureIsInvalid_ShouldThrowException() {
+        String validToken = jwtProvider.encode(claims2);
+        String invalidToken = validToken.substring(0, validToken.length() - 10);
+
+        Throwable throwable = assertThrows(UnauthenticatedException.class, () -> jwtProvider.decode(invalidToken));
+
+        assertThat(throwable.getMessage()).contains("Token signature is invalid");
+    }
+
+    @Test
+    void decode_WhenTokenIsMalformed_ShouldThrowException() {
+        String malformedToken = "not a jwt string";
+
+        Throwable throwable = assertThrows(UnauthenticatedException.class, () -> jwtProvider.decode(malformedToken));
 
         assertThat(throwable.getMessage()).contains("Token is invalid or corrupted");
     }


### PR DESCRIPTION
### What does this PR do?

- Added `encode` and `decode` methods to `IdentityTokenProvider`.
- Implemented new methods in `JwtProvider`.

Tests:
- Added tests for new methods to `JwtProviderTest`.

### Related tickets

Part of #95

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
