### PR TITLE
feat: implement user logout

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.jerael.booktracker.backend.application.service.token.config.AuthTokenProperties;
+import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
 import ru.jerael.booktracker.backend.domain.exception.factory.IdentityTokenExceptionFactory;
 import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
 import ru.jerael.booktracker.backend.domain.model.auth.*;
@@ -12,6 +13,7 @@ import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
 import ru.jerael.booktracker.backend.domain.service.token.IdentityTokenProvider;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -33,8 +35,26 @@ public class AuthTokenServiceImpl implements AuthTokenService {
     }
 
     @Override
-    public IdentityTokenClaims verifyToken(String token, IdentityTokenType expectedTokenType) {
-        IdentityTokenClaims claims = identityTokenProvider.decode(token);
+    @Transactional
+    public UUID revokeToken(String token) {
+        IdentityTokenClaims claims;
+        try {
+            claims = identityTokenProvider.decode(token);
+            verifyToken(claims, IdentityTokenType.REFRESH);
+        } catch (UnauthenticatedException e) {
+            throw IdentityTokenExceptionFactory.invalidToken();
+        }
+
+        List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByUserId(claims.userId());
+        RefreshToken foundRefreshToken = refreshTokens.stream()
+            .filter(refreshToken -> passwordHasher.verify(token, refreshToken.tokenHash()))
+            .findFirst()
+            .orElseThrow(IdentityTokenExceptionFactory::invalidToken);
+        refreshTokenRepository.deleteById(foundRefreshToken.id());
+        return claims.userId();
+    }
+
+    private void verifyToken(IdentityTokenClaims claims, IdentityTokenType expectedTokenType) {
         if (!properties.getIssuer().equals(claims.issuer())) {
             throw IdentityTokenExceptionFactory.invalidIssuer(claims.issuer());
         }
@@ -44,7 +64,6 @@ public class AuthTokenServiceImpl implements AuthTokenService {
         if (Instant.now().isAfter(claims.expiresAt())) {
             throw IdentityTokenExceptionFactory.tokenExpired();
         }
-        return claims;
     }
 
     private GeneratedToken createToken(UUID userId, IdentityTokenType tokenType) {

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/LogoutUserUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/LogoutUserUseCaseImpl.java
@@ -1,0 +1,23 @@
+package ru.jerael.booktracker.backend.application.usecase.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.jerael.booktracker.backend.domain.model.auth.LogoutPayload;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.usecase.auth.LogoutUserUseCase;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutUserUseCaseImpl implements LogoutUserUseCase {
+    private final AuthValidator authValidator;
+    private final AuthTokenService authTokenService;
+
+    @Override
+    @Transactional
+    public void execute(LogoutPayload data) {
+        authValidator.validateLogoutPayload(data);
+        authTokenService.revokeToken(data.refreshToken());
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImpl.java
@@ -1,43 +1,26 @@
 package ru.jerael.booktracker.backend.application.usecase.auth;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
-import ru.jerael.booktracker.backend.domain.exception.factory.IdentityTokenExceptionFactory;
-import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
-import ru.jerael.booktracker.backend.domain.model.auth.*;
-import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
 import ru.jerael.booktracker.backend.domain.usecase.auth.RefreshTokensUseCase;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
-import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class RefreshTokensUseCaseImpl implements RefreshTokensUseCase {
     private final AuthValidator authValidator;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final PasswordHasher passwordHasher;
     private final AuthTokenService authTokenService;
 
     @Override
+    @Transactional
     public TokenPair execute(RefreshTokenPayload data) {
         authValidator.validateRefreshTokenPayload(data);
-        String refreshToken = data.refreshToken();
-
-        IdentityTokenClaims claims;
-        try {
-            claims = authTokenService.verifyToken(refreshToken, IdentityTokenType.REFRESH);
-        } catch (UnauthenticatedException e) {
-            throw IdentityTokenExceptionFactory.invalidToken();
-        }
-
-        List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByUserId(claims.userId());
-        RefreshToken foundRefreshToken = refreshTokens.stream()
-            .filter(token -> passwordHasher.verify(refreshToken, token.tokenHash()))
-            .findFirst()
-            .orElseThrow(IdentityTokenExceptionFactory::invalidToken);
-        refreshTokenRepository.deleteById(foundRefreshToken.id());
-        return authTokenService.issueTokens(claims.userId());
+        UUID userId = authTokenService.revokeToken(data.refreshToken());
+        return authTokenService.issueTokens(userId);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImpl.java
@@ -7,6 +7,7 @@ import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
 import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.LogoutPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
@@ -61,12 +62,16 @@ public class AuthValidatorImpl implements AuthValidator {
     @Override
     public void validateRefreshTokenPayload(RefreshTokenPayload data) {
         List<ValidationError> errors = new ArrayList<>();
-        String refreshToken = data.refreshToken();
-
-        if (refreshToken == null || refreshToken.isBlank()) {
-            errors.add(CommonValidationErrorFactory.emptyField("refreshToken"));
+        errors.addAll(fieldValidator.validateRefreshToken(data.refreshToken()));
+        if (!errors.isEmpty()) {
+            throw new ValidationException(errors);
         }
+    }
 
+    @Override
+    public void validateLogoutPayload(LogoutPayload data) {
+        List<ValidationError> errors = new ArrayList<>();
+        errors.addAll(fieldValidator.validateRefreshToken(data.refreshToken()));
         if (!errors.isEmpty()) {
             throw new ValidationException(errors);
         }

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImpl.java
@@ -69,4 +69,13 @@ public class FieldValidatorImpl implements FieldValidator {
         }
         return errors;
     }
+
+    @Override
+    public List<ValidationError> validateRefreshToken(String refreshToken) {
+        List<ValidationError> errors = new ArrayList<>();
+        if (refreshToken == null || refreshToken.isBlank()) {
+            errors.add(CommonValidationErrorFactory.emptyField("refreshToken"));
+        }
+        return errors;
+    }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/LogoutPayload.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/auth/LogoutPayload.java
@@ -1,0 +1,3 @@
+package ru.jerael.booktracker.backend.domain.model.auth;
+
+public record LogoutPayload(String refreshToken) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/AuthTokenService.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/AuthTokenService.java
@@ -1,12 +1,10 @@
 package ru.jerael.booktracker.backend.domain.service.token;
 
-import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenClaims;
-import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import java.util.UUID;
 
 public interface AuthTokenService {
     TokenPair issueTokens(UUID userId);
 
-    IdentityTokenClaims verifyToken(String token, IdentityTokenType expectedTokenType);
+    UUID revokeToken(String token);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/auth/LogoutUserUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/auth/LogoutUserUseCase.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.usecase.auth;
+
+import ru.jerael.booktracker.backend.domain.model.auth.LogoutPayload;
+
+public interface LogoutUserUseCase {
+    void execute(LogoutPayload data);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/AuthValidator.java
@@ -1,6 +1,7 @@
 package ru.jerael.booktracker.backend.domain.validator;
 
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.LogoutPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
 
@@ -10,4 +11,6 @@ public interface AuthValidator {
     void validateLogin(UserLogin data);
 
     void validateRefreshTokenPayload(RefreshTokenPayload data);
+
+    void validateLogoutPayload(LogoutPayload data);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/FieldValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/FieldValidator.java
@@ -7,4 +7,6 @@ public interface FieldValidator {
     List<ValidationError> validateEmail(String email);
 
     List<ValidationError> validatePassword(String password);
+
+    List<ValidationError> validateRefreshToken(String refreshToken);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/AuthController.java
@@ -6,20 +6,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
-import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
-import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
-import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
+import ru.jerael.booktracker.backend.domain.model.auth.*;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
 import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.auth.LoginUserUseCase;
+import ru.jerael.booktracker.backend.domain.usecase.auth.LogoutUserUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.auth.RefreshTokensUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
-import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
-import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
+import ru.jerael.booktracker.backend.web.dto.auth.*;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
 import ru.jerael.booktracker.backend.web.mapper.AuthWebMapper;
@@ -36,6 +31,7 @@ public class AuthController {
     private final ConfirmRegistrationUseCase confirmRegistrationUseCase;
     private final LoginUserUseCase loginUserUseCase;
     private final RefreshTokensUseCase refreshTokensUseCase;
+    private final LogoutUserUseCase logoutUserUseCase;
 
     @Operation(summary = "Register new user")
     @PostMapping("/register")
@@ -68,5 +64,12 @@ public class AuthController {
         RefreshTokenPayload data = authWebMapper.toDomain(request);
         TokenPair tokenPair = refreshTokensUseCase.execute(data);
         return authWebMapper.toResponse(tokenPair);
+    }
+
+    @Operation(summary = "Logout")
+    @PostMapping("/logout")
+    public void logout(@Valid @RequestBody LogoutRequest request) {
+        LogoutPayload data = authWebMapper.toDomain(request);
+        logoutUserUseCase.execute(data);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/LogoutRequest.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/auth/LogoutRequest.java
@@ -1,0 +1,3 @@
+package ru.jerael.booktracker.backend.web.dto.auth;
+
+public record LogoutRequest(String refreshToken) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapper.java
@@ -1,14 +1,8 @@
 package ru.jerael.booktracker.backend.web.mapper;
 
 import org.springframework.stereotype.Component;
-import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
-import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
-import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
-import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
-import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
-import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
+import ru.jerael.booktracker.backend.domain.model.auth.*;
+import ru.jerael.booktracker.backend.web.dto.auth.*;
 
 @Component
 public class AuthWebMapper {
@@ -43,5 +37,11 @@ public class AuthWebMapper {
         if (request == null) return null;
 
         return new RefreshTokenPayload(request.refreshToken());
+    }
+
+    public LogoutPayload toDomain(LogoutRequest request) {
+        if (request == null) return null;
+
+        return new LogoutPayload(request.refreshToken());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImplTest.java
@@ -50,6 +50,14 @@ class AuthTokenServiceImplTest {
 
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String token = "token";
+    private final IdentityTokenClaims claims = new IdentityTokenClaims(
+        userId,
+        IdentityTokenType.REFRESH,
+        "issuer",
+        Instant.now().plusSeconds(100),
+        Instant.now().plusSeconds(1000)
+    );
+    private final UUID tokenId = UUID.fromString("b4e4e673-b851-4c0e-8626-a073941a018b");
 
     @Test
     void issueTokens_ShouldSaveHashedRefreshTokenAndReturnTokenPair() {
@@ -104,28 +112,29 @@ class AuthTokenServiceImplTest {
     }
 
     @Test
-    void verifyToken_WhenTokenIsValid_ShouldReturnClaims() {
-        IdentityTokenClaims claims = new IdentityTokenClaims(
+    void revokeToken_ShouldDeleteExistingTokenAndReturnUserId() {
+        RefreshToken refreshToken = new RefreshToken(
+            tokenId,
             userId,
-            IdentityTokenType.ACCESS,
-            "issuer",
-            Instant.now().minusSeconds(100),
+            "token hash",
             Instant.now().plusSeconds(1000)
         );
         when(properties.getIssuer()).thenReturn("issuer");
         when(identityTokenProvider.decode(token)).thenReturn(claims);
+        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of(refreshToken));
+        when(passwordHasher.verify(token, "token hash")).thenReturn(true);
 
-        IdentityTokenClaims result = service.verifyToken(token, IdentityTokenType.ACCESS);
+        UUID result = service.revokeToken(token);
 
-        assertEquals(claims, result);
-        assertEquals(userId, result.userId());
+        assertEquals(userId, result);
+        verify(refreshTokenRepository).deleteById(tokenId);
     }
 
     @Test
-    void verifyToken_WhenIssuerIsInvalid_ShouldThrowException() {
+    void revokeToken_WhenIssuerIsInvalid_ShouldThrowException() {
         IdentityTokenClaims claims = new IdentityTokenClaims(
             userId,
-            IdentityTokenType.ACCESS,
+            IdentityTokenType.REFRESH,
             "wrong issuer",
             Instant.now().minusSeconds(100),
             Instant.now().plusSeconds(1000)
@@ -134,13 +143,15 @@ class AuthTokenServiceImplTest {
         when(identityTokenProvider.decode(token)).thenReturn(claims);
 
         UnauthenticatedException exception =
-            assertThrows(UnauthenticatedException.class, () -> service.verifyToken(token, IdentityTokenType.ACCESS));
+            assertThrows(UnauthenticatedException.class, () -> service.revokeToken(token));
 
-        assertEquals(IdentityTokenErrorCode.INVALID_ISSUER, exception.getErrorCode());
+        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        verifyNoInteractions(refreshTokenRepository);
+        verifyNoInteractions(passwordHasher);
     }
 
     @Test
-    void verifyToken_WhenTokenTypeIsInvalid_ShouldThrowException() {
+    void revokeToken_WhenTokenTypeIsInvalid_ShouldThrowException() {
         IdentityTokenClaims claims = new IdentityTokenClaims(
             userId,
             IdentityTokenType.ACCESS,
@@ -152,16 +163,18 @@ class AuthTokenServiceImplTest {
         when(identityTokenProvider.decode(token)).thenReturn(claims);
 
         UnauthenticatedException exception =
-            assertThrows(UnauthenticatedException.class, () -> service.verifyToken(token, IdentityTokenType.REFRESH));
+            assertThrows(UnauthenticatedException.class, () -> service.revokeToken(token));
 
-        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN_TYPE, exception.getErrorCode());
+        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        verifyNoInteractions(refreshTokenRepository);
+        verifyNoInteractions(passwordHasher);
     }
 
     @Test
-    void verifyToken_WhenTokenIsExpired_ShouldThrowException() {
+    void revokeToken_WhenTokenIsExpired_ShouldThrowException() {
         IdentityTokenClaims claims = new IdentityTokenClaims(
             userId,
-            IdentityTokenType.ACCESS,
+            IdentityTokenType.REFRESH,
             "issuer",
             Instant.now().minusSeconds(1000),
             Instant.now().minusSeconds(100)
@@ -170,8 +183,38 @@ class AuthTokenServiceImplTest {
         when(identityTokenProvider.decode(token)).thenReturn(claims);
 
         UnauthenticatedException exception =
-            assertThrows(UnauthenticatedException.class, () -> service.verifyToken(token, IdentityTokenType.ACCESS));
+            assertThrows(UnauthenticatedException.class, () -> service.revokeToken(token));
 
-        assertEquals(IdentityTokenErrorCode.TOKEN_EXPIRED, exception.getErrorCode());
+        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        verifyNoInteractions(refreshTokenRepository);
+        verifyNoInteractions(passwordHasher);
+    }
+
+    @Test
+    void revokeToken_WhenTokenHashMismatched_ShouldThrowException() {
+        RefreshToken refreshToken = new RefreshToken(tokenId, userId, "token hash 2", Instant.now());
+        when(properties.getIssuer()).thenReturn("issuer");
+        when(identityTokenProvider.decode(token)).thenReturn(claims);
+        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of(refreshToken));
+        when(passwordHasher.verify(token, "token hash 2")).thenReturn(false);
+
+        UnauthenticatedException exception =
+            assertThrows(UnauthenticatedException.class, () -> service.revokeToken(token));
+
+        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        verify(refreshTokenRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void revokeToken_WhenNotFoundTokensForUser_ShouldThrowUnauthenticatedException() {
+        when(properties.getIssuer()).thenReturn("issuer");
+        when(identityTokenProvider.decode(token)).thenReturn(claims);
+        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of());
+
+        UnauthenticatedException exception =
+            assertThrows(UnauthenticatedException.class, () -> service.revokeToken(token));
+
+        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        verify(refreshTokenRepository, never()).deleteById(any());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/LogoutUserUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/LogoutUserUseCaseImplTest.java
@@ -1,0 +1,60 @@
+package ru.jerael.booktracker.backend.application.usecase.auth;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
+import ru.jerael.booktracker.backend.domain.exception.factory.IdentityTokenExceptionFactory;
+import ru.jerael.booktracker.backend.domain.model.auth.LogoutPayload;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutUserUseCaseImplTest {
+
+    @Mock
+    private AuthValidator authValidator;
+
+    @Mock
+    private AuthTokenService authTokenService;
+
+    @InjectMocks
+    private LogoutUserUseCaseImpl useCase;
+
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final String refreshToken = "user.jwt.token";
+    private final LogoutPayload data = new LogoutPayload(refreshToken);
+
+    @Test
+    void execute_WhenPayloadIsValid_ShouldRevokeOld() {
+        when(authTokenService.revokeToken(refreshToken)).thenReturn(userId);
+
+        useCase.execute(data);
+
+        verify(authValidator).validateLogoutPayload(data);
+        verify(authTokenService).revokeToken(refreshToken);
+    }
+
+    @Test
+    void execute_WhenValidationFails_ShouldThrowException() {
+        doThrow(new ValidationException(List.of())).when(authValidator).validateLogoutPayload(data);
+
+        assertThrows(ValidationException.class, () -> useCase.execute(data));
+
+        verifyNoInteractions(authTokenService);
+    }
+
+    @Test
+    void execute_WhenRevokeFails_ShouldThrowException() {
+        when(authTokenService.revokeToken(refreshToken)).thenThrow(IdentityTokenExceptionFactory.invalidToken());
+
+        assertThrows(UnauthenticatedException.class, () -> useCase.execute(data));
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/auth/RefreshTokensUseCaseImplTest.java
@@ -6,14 +6,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ru.jerael.booktracker.backend.domain.exception.UnauthenticatedException;
-import ru.jerael.booktracker.backend.domain.exception.code.IdentityTokenErrorCode;
+import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.factory.IdentityTokenExceptionFactory;
-import ru.jerael.booktracker.backend.domain.hasher.PasswordHasher;
-import ru.jerael.booktracker.backend.domain.model.auth.*;
-import ru.jerael.booktracker.backend.domain.repository.RefreshTokenRepository;
+import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
+import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,12 +25,6 @@ class RefreshTokensUseCaseImplTest {
     private AuthValidator authValidator;
 
     @Mock
-    private RefreshTokenRepository refreshTokenRepository;
-
-    @Mock
-    private PasswordHasher passwordHasher;
-
-    @Mock
     private AuthTokenService authTokenService;
 
     @InjectMocks
@@ -41,72 +33,36 @@ class RefreshTokensUseCaseImplTest {
     private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final String refreshToken = "user.jwt.token";
     private final RefreshTokenPayload data = new RefreshTokenPayload(refreshToken);
-    private final IdentityTokenClaims claims = new IdentityTokenClaims(
-        userId,
-        IdentityTokenType.REFRESH,
-        "issuer",
-        Instant.now().plusSeconds(100),
-        Instant.now().plusSeconds(1000)
-    );
-    private final UUID tokenId = UUID.fromString("b4e4e673-b851-4c0e-8626-a073941a018b");
 
     @Test
-    void execute_ShouldDeleteExistingTokenAndInsertNewAndReturnNewTokenPair() {
-        RefreshToken token = new RefreshToken(
-            tokenId,
-            userId,
-            "token hash",
-            Instant.now().plusSeconds(1000)
-        );
+    void execute_WhenPayloadIsValid_ShouldRevokeOldAndReturnNewTokens() {
         TokenPair tokenPair = new TokenPair("access token", "refresh token");
-        when(authTokenService.verifyToken(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
-        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of(token));
-        when(passwordHasher.verify(refreshToken, "token hash")).thenReturn(true);
+        when(authTokenService.revokeToken(refreshToken)).thenReturn(userId);
         when(authTokenService.issueTokens(userId)).thenReturn(tokenPair);
 
         TokenPair result = useCase.execute(data);
 
         assertEquals(tokenPair, result);
         verify(authValidator).validateRefreshTokenPayload(data);
-        verify(refreshTokenRepository).deleteById(tokenId);
+        verify(authTokenService).revokeToken(refreshToken);
         verify(authTokenService).issueTokens(userId);
     }
 
     @Test
-    void execute_WhenTokenVerificationFails_ShouldThrowInvalidCredentials() {
-        RefreshTokenPayload payload = new RefreshTokenPayload(refreshToken);
-        when(authTokenService.verifyToken(anyString(), eq(IdentityTokenType.REFRESH)))
-            .thenThrow(IdentityTokenExceptionFactory.tokenExpired());
+    void execute_WhenValidationFails_ShouldThrowException() {
+        doThrow(new ValidationException(List.of())).when(authValidator).validateRefreshTokenPayload(data);
 
-        UnauthenticatedException exception =
-            assertThrows(UnauthenticatedException.class, () -> useCase.execute(payload));
+        assertThrows(ValidationException.class, () -> useCase.execute(data));
 
-        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
-
-        verifyNoInteractions(refreshTokenRepository);
-        verifyNoInteractions(passwordHasher);
+        verifyNoInteractions(authTokenService);
     }
 
     @Test
-    void execute_WhenTokenHashMismatched_ShouldThrowUnauthenticatedException() {
-        RefreshToken token = new RefreshToken(tokenId, userId, "token hash 2", Instant.now());
-        when(authTokenService.verifyToken(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
-        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of(token));
-        when(passwordHasher.verify(refreshToken, "token hash 2")).thenReturn(false);
+    void execute_WhenRevokeFails_ShouldThrowException() {
+        when(authTokenService.revokeToken(refreshToken)).thenThrow(IdentityTokenExceptionFactory.invalidToken());
 
         assertThrows(UnauthenticatedException.class, () -> useCase.execute(data));
 
-        verify(refreshTokenRepository, never()).deleteById(any());
         verify(authTokenService, never()).issueTokens(any());
-    }
-
-    @Test
-    void execute_WhenNotFoundTokensForUser_ShouldThrowUnauthenticatedException() {
-        when(authTokenService.verifyToken(refreshToken, IdentityTokenType.REFRESH)).thenReturn(claims);
-        when(refreshTokenRepository.findAllByUserId(userId)).thenReturn(List.of());
-
-        UnauthenticatedException exception = assertThrows(UnauthenticatedException.class, () -> useCase.execute(data));
-
-        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/AuthValidatorImplTest.java
@@ -5,6 +5,7 @@ import ru.jerael.booktracker.backend.domain.constant.EmailVerificationRules;
 import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.code.CommonValidationErrorCode;
 import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
+import ru.jerael.booktracker.backend.domain.model.auth.LogoutPayload;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
 import ru.jerael.booktracker.backend.domain.validator.AuthValidator;
 import ru.jerael.booktracker.backend.domain.validator.FieldValidator;
@@ -81,6 +82,23 @@ class AuthValidatorImplTest {
 
         ValidationException ex =
             assertThrows(ValidationException.class, () -> authValidator.validateRefreshTokenPayload(data));
+
+        assertThat(ex.getErrors()).anyMatch(e -> e.field().equals("refreshToken"));
+    }
+
+    @Test
+    void validateLogoutPayload_WhenValid_ShouldNotThrowException() {
+        LogoutPayload data = new LogoutPayload(refreshToken);
+
+        assertDoesNotThrow(() -> authValidator.validateLogoutPayload(data));
+    }
+
+    @Test
+    void validateLogoutPayload_WhenRefreshTokenIsBlank_ShouldThrowException() {
+        LogoutPayload data = new LogoutPayload("  ");
+
+        ValidationException ex =
+            assertThrows(ValidationException.class, () -> authValidator.validateLogoutPayload(data));
 
         assertThat(ex.getErrors()).anyMatch(e -> e.field().equals("refreshToken"));
     }

--- a/src/test/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/validator/FieldValidatorImplTest.java
@@ -147,4 +147,24 @@ class FieldValidatorImplTest {
 
         assertNotNull(errors.get(0).params().get("forbidden"));
     }
+
+    @Test
+    void validateRefreshToken_WhenValid_ShouldReturnEmptyList() {
+        String refreshToken = "token";
+
+        List<ValidationError> errors = fieldValidator.validateRefreshToken(refreshToken);
+
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void validateRefreshToken_WhenRefreshTokenIsBlank_ShouldReturnEmptyFieldError() {
+        String refreshToken = "  ";
+
+        List<ValidationError> errors = fieldValidator.validateRefreshToken(refreshToken);
+
+        assertThat(errors)
+            .extracting("code")
+            .contains(CommonValidationErrorCode.FIELD_CANNOT_BE_EMPTY.name());
+    }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/AuthControllerTest.java
@@ -17,13 +17,11 @@ import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
 import ru.jerael.booktracker.backend.domain.usecase.auth.ConfirmRegistrationUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.auth.LoginUserUseCase;
+import ru.jerael.booktracker.backend.domain.usecase.auth.LogoutUserUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.auth.RefreshTokensUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.user.CreateUserUseCase;
 import ru.jerael.booktracker.backend.web.config.WebProperties;
-import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
-import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
+import ru.jerael.booktracker.backend.web.dto.auth.*;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
 import ru.jerael.booktracker.backend.web.mapper.AuthWebMapper;
@@ -60,6 +58,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private RefreshTokensUseCase refreshTokensUseCase;
+
+    @MockitoBean
+    private LogoutUserUseCase logoutUserUseCase;
 
     private final String email = "test@example.com";
     private final String password = "Password123!";
@@ -165,5 +166,17 @@ class AuthControllerTest {
                 assertEquals(accessToken, response.accessToken());
                 assertEquals(refreshToken, response.refreshToken());
             });
+    }
+
+    @Test
+    void logout() {
+        LogoutRequest request = new LogoutRequest(refreshToken);
+
+        assertThat(
+            mockMvcTester.post().uri("/api/v1/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .hasStatus(HttpStatus.OK);
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/AuthWebMapperTest.java
@@ -1,14 +1,8 @@
 package ru.jerael.booktracker.backend.web.mapper;
 
 import org.junit.jupiter.api.Test;
-import ru.jerael.booktracker.backend.domain.model.auth.ConfirmRegistration;
-import ru.jerael.booktracker.backend.domain.model.auth.RefreshTokenPayload;
-import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
-import ru.jerael.booktracker.backend.domain.model.auth.UserLogin;
-import ru.jerael.booktracker.backend.web.dto.auth.AuthResponse;
-import ru.jerael.booktracker.backend.web.dto.auth.ConfirmRegistrationRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.LoginRequest;
-import ru.jerael.booktracker.backend.web.dto.auth.RefreshTokensRequest;
+import ru.jerael.booktracker.backend.domain.model.auth.*;
+import ru.jerael.booktracker.backend.web.dto.auth.*;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -57,6 +51,15 @@ class AuthWebMapperTest {
         RefreshTokensRequest request = new RefreshTokensRequest(refreshToken);
 
         RefreshTokenPayload domain = authWebMapper.toDomain(request);
+
+        assertEquals(refreshToken, domain.refreshToken());
+    }
+
+    @Test
+    void toDomain_LogoutPayload() {
+        LogoutRequest request = new LogoutRequest(refreshToken);
+
+        LogoutPayload domain = authWebMapper.toDomain(request);
 
         assertEquals(refreshToken, domain.refreshToken());
     }


### PR DESCRIPTION
### What does this PR do?

- Added `LogoutPayload` and `LogoutRequest` models.
- Added mapper `LogoutRequest` -> `LogoutPayload` to `AuthWebMapper`.
- Implemented `revokeToken` method in `AuthTokenService`.
- Moved token logic from `RefreshTokensUseCaseImpl` to `AuthTokenServiceImpl.revokeToken`.
- Moved `refreshToken` validation logic to `FieldValidator`.
- Added `validateLogoutPayload` method to `AuthValidator`.
- Implemented `LogoutUserUseCase`.
- Added `POST /auth/logout` endpoint to `AuthController`.

Tests:
- Added tests for `LogoutUserUseCaseImpl`.
- Updated tests for `AuthTokenServiceImpl`, `RefreshTokensUseCaseImpl`, `AuthValidatorImpl`, `FieldValidatorImpl`, `AuthController` and `AuthWebMapper`.

### Related tickets

Closes #98

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
