### PR TITLE
feat: add authenticateToken to AuthTokenService

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImpl.java
@@ -39,8 +39,7 @@ public class AuthTokenServiceImpl implements AuthTokenService {
     public UUID revokeToken(String token) {
         IdentityTokenClaims claims;
         try {
-            claims = identityTokenProvider.decode(token);
-            verifyToken(claims, IdentityTokenType.REFRESH);
+            claims = authenticateToken(token, IdentityTokenType.REFRESH);
         } catch (UnauthenticatedException e) {
             throw IdentityTokenExceptionFactory.invalidToken();
         }
@@ -52,6 +51,13 @@ public class AuthTokenServiceImpl implements AuthTokenService {
             .orElseThrow(IdentityTokenExceptionFactory::invalidToken);
         refreshTokenRepository.deleteById(foundRefreshToken.id());
         return claims.userId();
+    }
+
+    @Override
+    public IdentityTokenClaims authenticateToken(String token, IdentityTokenType expectedTokenType) {
+        IdentityTokenClaims claims = identityTokenProvider.decode(token);
+        verifyToken(claims, expectedTokenType);
+        return claims;
     }
 
     private void verifyToken(IdentityTokenClaims claims, IdentityTokenType expectedTokenType) {

--- a/src/main/java/ru/jerael/booktracker/backend/domain/service/token/AuthTokenService.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/service/token/AuthTokenService.java
@@ -1,5 +1,7 @@
 package ru.jerael.booktracker.backend.domain.service.token;
 
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenClaims;
+import ru.jerael.booktracker.backend.domain.model.auth.IdentityTokenType;
 import ru.jerael.booktracker.backend.domain.model.auth.TokenPair;
 import java.util.UUID;
 
@@ -7,4 +9,6 @@ public interface AuthTokenService {
     TokenPair issueTokens(UUID userId);
 
     UUID revokeToken(String token);
+
+    IdentityTokenClaims authenticateToken(String token, IdentityTokenType expectedTokenType);
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/service/token/AuthTokenServiceImplTest.java
@@ -217,4 +217,76 @@ class AuthTokenServiceImplTest {
         assertEquals(IdentityTokenErrorCode.INVALID_TOKEN, exception.getErrorCode());
         verify(refreshTokenRepository, never()).deleteById(any());
     }
+
+    @Test
+    void authenticateToken_WhenTokenIsValid_ShouldReturnClaims() {
+        IdentityTokenClaims claims = new IdentityTokenClaims(
+            userId,
+            IdentityTokenType.ACCESS,
+            "issuer",
+            Instant.now().minusSeconds(100),
+            Instant.now().plusSeconds(1000)
+        );
+        when(properties.getIssuer()).thenReturn("issuer");
+        when(identityTokenProvider.decode(token)).thenReturn(claims);
+
+        IdentityTokenClaims result = service.authenticateToken(token, IdentityTokenType.ACCESS);
+
+        assertEquals(claims, result);
+        assertEquals(userId, result.userId());
+    }
+
+    @Test
+    void authenticateToken_WhenIssuerIsInvalid_ShouldThrowInvalidIssuerError() {
+        IdentityTokenClaims claims = new IdentityTokenClaims(
+            userId,
+            IdentityTokenType.ACCESS,
+            "wrong issuer",
+            Instant.now().minusSeconds(100),
+            Instant.now().plusSeconds(1000)
+        );
+        when(properties.getIssuer()).thenReturn("issuer");
+        when(identityTokenProvider.decode(token)).thenReturn(claims);
+
+        UnauthenticatedException exception = assertThrows(UnauthenticatedException.class,
+            () -> service.authenticateToken(token, IdentityTokenType.ACCESS));
+
+        assertEquals(IdentityTokenErrorCode.INVALID_ISSUER, exception.getErrorCode());
+    }
+
+    @Test
+    void authenticateToken_WhenTokenTypeIsInvalid_ShouldThrowInvalidTokenTypeError() {
+        IdentityTokenClaims claims = new IdentityTokenClaims(
+            userId,
+            IdentityTokenType.REFRESH,
+            "issuer",
+            Instant.now().minusSeconds(100),
+            Instant.now().plusSeconds(1000)
+        );
+        when(properties.getIssuer()).thenReturn("issuer");
+        when(identityTokenProvider.decode(token)).thenReturn(claims);
+
+        UnauthenticatedException exception = assertThrows(UnauthenticatedException.class,
+            () -> service.authenticateToken(token, IdentityTokenType.ACCESS));
+
+        assertEquals(IdentityTokenErrorCode.INVALID_TOKEN_TYPE, exception.getErrorCode());
+    }
+
+    @Test
+    void authenticateToken_WhenTokenIsExpired_ShouldThrowTokenExpiredError() {
+        IdentityTokenClaims claims = new IdentityTokenClaims(
+            userId,
+            IdentityTokenType.ACCESS,
+            "issuer",
+            Instant.now().minusSeconds(1000),
+            Instant.now().minusSeconds(100)
+        );
+        when(properties.getIssuer()).thenReturn("issuer");
+        when(identityTokenProvider.decode(token)).thenReturn(claims);
+
+        UnauthenticatedException exception = assertThrows(UnauthenticatedException.class,
+            () -> service.authenticateToken(token, IdentityTokenType.ACCESS));
+
+        assertEquals(IdentityTokenErrorCode.TOKEN_EXPIRED, exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
### What does this PR do?

- Added `authenticateToken` method to `AuthTokenService`.
- Refactored `AuthTokenService.revokeToken` to using new `authenticateToken`.

Tests:
- Added tests for `AuthTokenService.authenticateToken`.

### Related tickets

Part of #102

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
