### PR TITLE
feat: integrate authenticated userId into book endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <commons-validator.version>1.10.1</commons-validator.version>
         <nimbus-jose-jwt.version>10.8</nimbus-jose-jwt.version>
         <spring-security-crypto.version>7.0.3</spring-security-crypto.version>
+        <spring-security-test.version>7.0.3</spring-security-test.version>
     </properties>
     <dependencies>
 
@@ -193,6 +194,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring-security-test.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/BookController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/BookController.java
@@ -10,6 +10,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.*;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import ru.jerael.booktracker.backend.domain.constant.BookRules;
@@ -52,7 +53,7 @@ public class BookController {
 
     @Operation(summary = "Get all books")
     @GetMapping
-    public PagedModel<BookResponse> getAll(@ParameterObject Pageable pageable) {
+    public PagedModel<BookResponse> getAll(@ParameterObject Pageable pageable, @AuthenticationPrincipal UUID userId) {
         Sort.Order order = pageable.getSort().stream().findFirst().orElse(null);
         String sortBy = order != null ? order.getProperty() : PaginationRules.DEFAULT_SORT_FIELD;
         SortDirection direction = order != null && order.isAscending()
@@ -65,7 +66,6 @@ public class BookController {
             sortBy,
             direction
         );
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
         PageResult<Book> books = getBooksUseCase.execute(query, userId);
         PageResult<BookResponse> bookResponses = books.map(bookWebMapper::toResponse);
         Page<BookResponse> page = new PageImpl<>(
@@ -78,8 +78,7 @@ public class BookController {
 
     @Operation(summary = "Get book by id")
     @GetMapping("/{id}")
-    public BookResponse getById(@PathVariable UUID id) {
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+    public BookResponse getById(@PathVariable UUID id, @AuthenticationPrincipal UUID userId) {
         Book book = getBookByIdUseCase.execute(id, userId);
         return bookWebMapper.toResponse(book);
     }
@@ -87,16 +86,18 @@ public class BookController {
     @Operation(summary = "Delete book by id")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteBook(@PathVariable UUID id) {
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+    public void deleteBook(@PathVariable UUID id, @AuthenticationPrincipal UUID userId) {
         deleteBookUseCase.execute(id, userId);
     }
 
     @Operation(summary = "Update book details")
     @PatchMapping("/{id}")
-    public BookResponse updateDetails(@PathVariable UUID id, @Valid @RequestBody BookDetailsUpdateRequest request) {
+    public BookResponse updateDetails(
+        @PathVariable UUID id,
+        @Valid @RequestBody BookDetailsUpdateRequest request,
+        @AuthenticationPrincipal UUID userId
+    ) {
         BookDetailsUpdate data = bookWebMapper.toDomain(request);
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
         Book book = updateBookDetailsUseCase.execute(id, userId, data);
         return bookWebMapper.toResponse(book);
     }
@@ -104,9 +105,8 @@ public class BookController {
     @Operation(summary = "Create book")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BookResponse create(@Valid @RequestBody BookCreationRequest request) {
+    public BookResponse create(@Valid @RequestBody BookCreationRequest request, @AuthenticationPrincipal UUID userId) {
         BookCreation data = bookWebMapper.toDomain(request);
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
         Book book = createBookUseCase.execute(data, userId);
         return bookWebMapper.toResponse(book);
     }
@@ -115,11 +115,11 @@ public class BookController {
     @PostMapping(value = "/{id}/cover", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BookResponse uploadCover(
         @PathVariable UUID id,
-        @RequestParam(BookRules.COVER_FIELD_NAME) MultipartFile file
+        @RequestParam(BookRules.COVER_FIELD_NAME) MultipartFile file,
+        @AuthenticationPrincipal UUID userId
     ) {
         fileValidator.validate(file, BookRules.COVER_FIELD_NAME);
         UploadCover data = uploadCoverWebMapper.toDomain(file);
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
         Book book = uploadCoverUseCase.execute(id, userId, data);
         return bookWebMapper.toResponse(book);
     }
@@ -127,15 +127,13 @@ public class BookController {
     @Operation(summary = "Delete book cover")
     @DeleteMapping("/{id}/cover")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteCover(@PathVariable UUID id) {
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+    public void deleteCover(@PathVariable UUID id, @AuthenticationPrincipal UUID userId) {
         deleteCoverUseCase.execute(id, userId);
     }
 
     @Operation(summary = "Get book cover")
     @GetMapping("/{id}/cover")
-    public ResponseEntity<Resource> getCover(@PathVariable UUID id) {
-        UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+    public ResponseEntity<Resource> getCover(@PathVariable UUID id, @AuthenticationPrincipal UUID userId) {
         ImageFile imageFile = getBookCoverUseCase.execute(id, userId);
         return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "filename=\"" + imageFile.fileName() + "\"")

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import ru.jerael.booktracker.backend.domain.exception.factory.BookExceptionFactory;
@@ -15,6 +16,7 @@ import ru.jerael.booktracker.backend.domain.model.book.*;
 import ru.jerael.booktracker.backend.domain.model.image.ImageFile;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
 import ru.jerael.booktracker.backend.domain.usecase.book.*;
 import ru.jerael.booktracker.backend.web.config.WebProperties;
 import ru.jerael.booktracker.backend.web.dto.book.BookCreationRequest;
@@ -24,6 +26,7 @@ import ru.jerael.booktracker.backend.web.exception.handler.GlobalExceptionHandle
 import ru.jerael.booktracker.backend.web.mapper.BookWebMapper;
 import ru.jerael.booktracker.backend.web.mapper.GenreWebMapper;
 import ru.jerael.booktracker.backend.web.mapper.UploadCoverWebMapper;
+import ru.jerael.booktracker.backend.web.security.SecurityConfig;
 import ru.jerael.booktracker.backend.web.validator.FileValidator;
 import tools.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
@@ -37,9 +40,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
 @WebMvcTest(BookController.class)
-@Import({GlobalExceptionHandler.class, BookWebMapper.class, GenreWebMapper.class})
+@Import({GlobalExceptionHandler.class, BookWebMapper.class, GenreWebMapper.class, SecurityConfig.class})
 class BookControllerTest {
 
     @Autowired
@@ -84,12 +88,19 @@ class BookControllerTest {
     @MockitoBean
     private UploadCoverWebMapper uploadCoverWebMapper;
 
+    @MockitoBean
+    private AuthTokenService authTokenService;
+
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
-    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e"); // TODO: REMOVE THIS
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
     private final String author = "author";
     private final BookStatus status = BookStatus.READING;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    private UsernamePasswordAuthenticationToken getAuth() {
+        return new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+    }
 
     @Test
     void getAll_ShouldReturnListOfBookResponses() {
@@ -100,16 +111,17 @@ class BookControllerTest {
         when(getBooksUseCase.execute(any(PageQuery.class), eq(userId))).thenReturn(pageResult);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
-        var response = mockMvcTester.get().uri("/api/v1/books?page=0&size=10").exchange();
+        var mockResponse = mockMvcTester.get().uri("/api/v1/books?page=0&size=10")
+            .with(authentication(getAuth())).exchange();
 
-        assertThat(response)
+        assertThat(mockResponse)
             .hasStatus(HttpStatus.OK)
             .bodyJson()
             .extractingPath("$.content")
             .convertTo(BookResponse[].class)
             .satisfies(responses -> assertThat(responses).containsExactly(bookResponse));
 
-        assertThat(response)
+        assertThat(mockResponse)
             .bodyJson()
             .extractingPath("$.page.totalElements").isEqualTo(1);
 
@@ -121,7 +133,9 @@ class BookControllerTest {
         UUID id = UUID.fromString("31d3f5e3-7faf-4678-a3cf-4657d8875a82");
         when(getBookByIdUseCase.execute(id, userId)).thenThrow(BookExceptionFactory.bookNotFound(id));
 
-        assertThat(mockMvcTester.get().uri("/api/v1/books/" + id))
+        var mockResponse = mockMvcTester.get().uri("/api/v1/books/" + id).with(authentication(getAuth()));
+
+        assertThat(mockResponse)
             .hasStatus(HttpStatus.NOT_FOUND)
             .bodyJson()
             .extractingPath("$.detail")
@@ -132,9 +146,9 @@ class BookControllerTest {
 
     @Test
     void deleteBook_ShouldReturnNoContent() {
-        var response = mockMvcTester.delete().uri("/api/v1/books/" + id);
+        var mockResponse = mockMvcTester.delete().uri("/api/v1/books/" + id).with(authentication(getAuth()));
 
-        assertThat(response).hasStatus(HttpStatus.NO_CONTENT);
+        assertThat(mockResponse).hasStatus(HttpStatus.NO_CONTENT);
         verify(deleteBookUseCase).execute(id, userId);
     }
 
@@ -154,11 +168,12 @@ class BookControllerTest {
         when(updateBookDetailsUseCase.execute(id, userId, data)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
-        assertThat(
-            mockMvcTester.patch().uri("/api/v1/books/" + id)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
+        var mockResponse = mockMvcTester.patch().uri("/api/v1/books/" + id)
+            .with(authentication(getAuth()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request));
+
+        assertThat(mockResponse)
             .hasStatus(HttpStatus.OK)
             .bodyJson()
             .convertTo(BookResponse.class)
@@ -180,11 +195,12 @@ class BookControllerTest {
         when(createBookUseCase.execute(data, userId)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
-        assertThat(
-            mockMvcTester.post().uri("/api/v1/books")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
+        var mockResponse = mockMvcTester.post().uri("/api/v1/books")
+            .with(authentication(getAuth()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request));
+
+        assertThat(mockResponse)
             .hasStatus(HttpStatus.CREATED)
             .bodyJson()
             .convertTo(BookResponse.class)
@@ -213,11 +229,12 @@ class BookControllerTest {
         when(uploadCoverUseCase.execute(id, userId, data)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
 
-        assertThat(
-            mockMvcTester.post().uri("/api/v1/books/" + id + "/cover")
-                .multipart()
-                .file(mockMultipartFile)
-        )
+        var mockResponse = mockMvcTester.post().uri("/api/v1/books/" + id + "/cover")
+            .with(authentication(getAuth()))
+            .multipart()
+            .file(mockMultipartFile);
+
+        assertThat(mockResponse)
             .hasStatus(HttpStatus.OK)
             .bodyJson()
             .convertTo(BookResponse.class)
@@ -226,9 +243,10 @@ class BookControllerTest {
 
     @Test
     void deleteCover_ShouldReturnNoContent() {
-        var response = mockMvcTester.delete().uri("/api/v1/books/" + id + "/cover");
+        var mockResponse = mockMvcTester.delete().uri("/api/v1/books/" + id + "/cover")
+            .with(authentication(getAuth()));
 
-        assertThat(response).hasStatus(HttpStatus.NO_CONTENT);
+        assertThat(mockResponse).hasStatus(HttpStatus.NO_CONTENT);
         verify(deleteCoverUseCase).execute(id, userId);
     }
 
@@ -245,7 +263,10 @@ class BookControllerTest {
         );
         when(getBookCoverUseCase.execute(id, userId)).thenReturn(imageFile);
 
-        assertThat(mockMvcTester.get().uri("/api/v1/books/" + id + "/cover"))
+        var mockResponse = mockMvcTester.get().uri("/api/v1/books/" + id + "/cover")
+            .with(authentication(getAuth()));
+
+        assertThat(mockResponse)
             .hasStatus(HttpStatus.OK)
             .hasContentType(MediaType.parseMediaType(contentType))
             .hasHeader(HttpHeaders.CONTENT_DISPOSITION, "filename=\"" + coverFileName + "\"")


### PR DESCRIPTION
### What does this PR do?

- Added `spring-security-test` dependency to `pom.xml`.
- Added `AuthenticationPrincipal` annotation into all `BookController` endpoints.

Tests:
- Updated tests for `BookController`.

### Related tickets

Closes #105

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
