### PR TITLE
feat: implement user details endpoint

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/user/GetUserUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/user/GetUserUseCaseImpl.java
@@ -1,0 +1,20 @@
+package ru.jerael.booktracker.backend.application.usecase.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ru.jerael.booktracker.backend.domain.exception.factory.UserExceptionFactory;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import ru.jerael.booktracker.backend.domain.usecase.user.GetUserUseCase;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserUseCaseImpl implements GetUserUseCase {
+    private final UserRepository userRepository;
+
+    @Override
+    public User execute(UUID userId) {
+        return userRepository.findById(userId).orElseThrow(() -> UserExceptionFactory.userNotFound(userId));
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/user/GetUserUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/user/GetUserUseCase.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.usecase.user;
+
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import java.util.UUID;
+
+public interface GetUserUseCase {
+    User execute(UUID userId);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/UserController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/UserController.java
@@ -1,0 +1,30 @@
+package ru.jerael.booktracker.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.usecase.user.GetUserUseCase;
+import ru.jerael.booktracker.backend.web.dto.user.UserResponse;
+import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
+import java.util.UUID;
+
+@Tag(name = "Users")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final GetUserUseCase getUserUseCase;
+    private final UserWebMapper userWebMapper;
+
+    @Operation(summary = "Get current user details")
+    @GetMapping("/me")
+    public UserResponse getMe(@AuthenticationPrincipal UUID userId) {
+        User user = getUserUseCase.execute(userId);
+        return userWebMapper.toResponse(user);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/user/UserResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/user/UserResponse.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.web.dto.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserResponse(
+    UUID userId,
+    String email,
+    boolean isVerified,
+    Instant createdAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapper.java
@@ -1,10 +1,12 @@
 package ru.jerael.booktracker.backend.web.mapper;
 
 import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.user.User;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import ru.jerael.booktracker.backend.web.dto.user.UserResponse;
 
 @Component
 public class UserWebMapper {
@@ -24,6 +26,17 @@ public class UserWebMapper {
         return new UserCreation(
             request.email(),
             request.password()
+        );
+    }
+
+    public UserResponse toResponse(User user) {
+        if (user == null) return null;
+
+        return new UserResponse(
+            user.id(),
+            user.email(),
+            user.isVerified(),
+            user.createdAt()
         );
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/user/GetUserUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/user/GetUserUseCaseImplTest.java
@@ -1,0 +1,40 @@
+package ru.jerael.booktracker.backend.application.usecase.user;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetUserUseCaseImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private GetUserUseCaseImpl useCase;
+
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final String email = "test@example.com";
+    private final String passwordHash = "password hash";
+
+    @Test
+    void execute_WhenFound_ShouldReturnUser() {
+        User user = new User(userId, email, passwordHash, true, Instant.now());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        User result = useCase.execute(userId);
+
+        assertEquals(user, result);
+        verify(userRepository).findById(userId);
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/UserControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/UserControllerTest.java
@@ -1,0 +1,69 @@
+package ru.jerael.booktracker.backend.web.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import ru.jerael.booktracker.backend.domain.model.user.User;
+import ru.jerael.booktracker.backend.domain.service.token.AuthTokenService;
+import ru.jerael.booktracker.backend.domain.usecase.user.GetUserUseCase;
+import ru.jerael.booktracker.backend.web.config.WebProperties;
+import ru.jerael.booktracker.backend.web.dto.user.UserResponse;
+import ru.jerael.booktracker.backend.web.exception.handler.GlobalExceptionHandler;
+import ru.jerael.booktracker.backend.web.mapper.UserWebMapper;
+import ru.jerael.booktracker.backend.web.security.SecurityConfig;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+@WebMvcTest(UserController.class)
+@Import({GlobalExceptionHandler.class, UserWebMapper.class, SecurityConfig.class})
+class UserControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvcTester;
+
+    @MockitoBean
+    private WebProperties webProperties;
+
+    @MockitoBean
+    private AuthTokenService authTokenService;
+
+    @MockitoBean
+    private GetUserUseCase getUserUseCase;
+
+    @MockitoBean
+    private UserWebMapper userWebMapper;
+
+    private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final String email = "test@example.com";
+    private final String passwordHash = "password hash";
+    private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
+
+    private UsernamePasswordAuthenticationToken getAuth() {
+        return new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+    }
+
+    @Test
+    void getMe_WhenAuthenticated_ShouldReturnUserResponse() {
+        User user = new User(userId, email, passwordHash, true, createdAt);
+        UserResponse userResponse = new UserResponse(userId, email, true, createdAt);
+        when(getUserUseCase.execute(userId)).thenReturn(user);
+        when(userWebMapper.toResponse(user)).thenReturn(userResponse);
+
+        var mockResponse = mockMvcTester.get().uri("/api/v1/users/me").with(authentication(getAuth()));
+
+        assertThat(mockResponse)
+            .hasStatus(HttpStatus.OK)
+            .bodyJson()
+            .extractingPath("$.email")
+            .isEqualTo(email);
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/UserWebMapperTest.java
@@ -1,14 +1,15 @@
 package ru.jerael.booktracker.backend.web.mapper;
 
 import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.domain.model.user.User;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreation;
 import ru.jerael.booktracker.backend.domain.model.user.UserCreationResult;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationRequest;
 import ru.jerael.booktracker.backend.web.dto.user.UserCreationResponse;
+import ru.jerael.booktracker.backend.web.dto.user.UserResponse;
 import java.time.Instant;
 import java.util.UUID;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class UserWebMapperTest {
     private final UserWebMapper userWebMapper = new UserWebMapper();
@@ -17,9 +18,10 @@ class UserWebMapperTest {
     private final String password = "password";
     private final UUID userId = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final Instant expiresAt = Instant.ofEpochMilli(1771249999347L);
+    private final Instant createdAt = Instant.ofEpochMilli(1771246999347L);
 
     @Test
-    void toResponse() {
+    void toResponse_UserCreationResponse() {
         UserCreationResult result = new UserCreationResult(userId, email, expiresAt);
 
         UserCreationResponse response = userWebMapper.toResponse(result);
@@ -39,5 +41,18 @@ class UserWebMapperTest {
         assertNotNull(domain);
         assertEquals(email, domain.email());
         assertEquals(password, domain.password());
+    }
+
+    @Test
+    void toResponse_UserResponse() {
+        User user = new User(userId, email, "password hash", true, createdAt);
+
+        UserResponse response = userWebMapper.toResponse(user);
+
+        assertNotNull(response);
+        assertEquals(userId, response.userId());
+        assertEquals(email, response.email());
+        assertTrue(response.isVerified());
+        assertEquals(createdAt, response.createdAt());
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Added `UserResponse` dto.
- Added mapper `User` -> `UserResponse` to `UserWebMapper`.
- Implemented `GetUserUseCase`.
- Added `GET /users/me` endpoint to `UserController`.

Tests:
- Added tests for `GetUserUseCaseImpl` and `UserController`.
- Updated tests for `UserWebMapper`.

### Related tickets

Closes #107

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
