### PR TITLE
feat: add migrations for new tables

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class BookEntity {
     @Id
-    @Column(name = "book_id")
+    @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -49,3 +49,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml
   - include:
       file: classpath:/db/changelog/changes/25__add-unknown-publisher-to-publishers.yaml
+  - include:
+      file: classpath:/db/changelog/changes/26__migrate-authors.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -39,3 +39,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/19__notes-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/20__reading_attempts-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/21__reading_sessions-schema.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -23,3 +23,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/11__email_verifications-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/12__refresh_tokens-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/13__rename-book_id-field-and-update-fk.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -31,3 +31,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/15__book_authors-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/16__publishers-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/17__languages-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/18__languages-data.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -25,3 +25,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/12__refresh_tokens-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/13__rename-book_id-field-and-update-fk.yaml
+  - include:
+      file: classpath:/db/changelog/changes/14__authors-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/15__book_authors-schema.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -35,3 +35,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/17__languages-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/18__languages-data.yaml
+  - include:
+      file: classpath:/db/changelog/changes/19__notes-schema.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -53,3 +53,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/26__migrate-authors.yaml
   - include:
       file: classpath:/db/changelog/changes/27__link-books-to-authors.yaml
+  - include:
+      file: classpath:/db/changelog/changes/28__add-attempts-for-books-to-reading_attempts.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -41,3 +41,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/20__reading_attempts-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/21__reading_sessions-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/22__add-nullable-fields-to-books.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -43,3 +43,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/21__reading_sessions-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/22__add-nullable-fields-to-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/23__set-finished_at-nullable-in-reading_attempts.yaml
+  - include:
+      file: classpath:/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -55,3 +55,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/27__link-books-to-authors.yaml
   - include:
       file: classpath:/db/changelog/changes/28__add-attempts-for-books-to-reading_attempts.yaml
+  - include:
+      file: classpath:/db/changelog/changes/29__fill-publisher_id-and-language_code-in-books.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -37,3 +37,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/18__languages-data.yaml
   - include:
       file: classpath:/db/changelog/changes/19__notes-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/20__reading_attempts-schema.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -47,3 +47,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/23__set-finished_at-nullable-in-reading_attempts.yaml
   - include:
       file: classpath:/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml
+  - include:
+      file: classpath:/db/changelog/changes/25__add-unknown-publisher-to-publishers.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -29,3 +29,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/14__authors-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/15__book_authors-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/16__publishers-schema.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -51,3 +51,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/25__add-unknown-publisher-to-publishers.yaml
   - include:
       file: classpath:/db/changelog/changes/26__migrate-authors.yaml
+  - include:
+      file: classpath:/db/changelog/changes/27__link-books-to-authors.yaml

--- a/src/main/resources/db/changelog/changes/13__rename-book_id-field-and-update-fk.yaml
+++ b/src/main/resources/db/changelog/changes/13__rename-book_id-field-and-update-fk.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 13__rename-book_id-to-id-and-update-fk
+      author: Jerael
+      comment: rename book_id to id in books table and update foreign key in book_genres table
+      changes:
+        - renameColumn:
+            tableName: books
+            oldColumnName: book_id
+            newColumnName: id
+        - dropForeignKeyConstraint:
+            baseTableName: book_genres
+            constraintName: fk_book_genres_book_id
+        - addForeignKeyConstraint:
+            baseTableName: book_genres
+            baseColumnNames: book_id
+            referencedTableName: books
+            referencedColumnNames: id
+            constraintName: fk_book_genres_book_id
+            onDelete: CASCADE

--- a/src/main/resources/db/changelog/changes/14__authors-schema.yaml
+++ b/src/main/resources/db/changelog/changes/14__authors-schema.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 14__create-authors-table
+      author: Jerael
+      comment: create authors table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: authors
+      changes:
+        - createTable:
+            tableName: authors
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: full_name
+                  type: varchar(500)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_authors_full_name
+        - addPrimaryKey:
+            tableName: authors
+            columnNames: id
+            constraintName: pk_authors

--- a/src/main/resources/db/changelog/changes/15__book_authors-schema.yaml
+++ b/src/main/resources/db/changelog/changes/15__book_authors-schema.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 15__create-book_authors-table
+      author: Jerael
+      comment: create book_authors table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: book_authors
+      changes:
+        - createTable:
+            tableName: book_authors
+            columns:
+              - column:
+                  name: book_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: author_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: book_authors
+            columnNames: book_id, author_id
+            constraintName: pk_book_authors
+        - addForeignKeyConstraint:
+            baseTableName: book_authors
+            baseColumnNames: book_id
+            referencedTableName: books
+            referencedColumnNames: id
+            constraintName: fk_book_authors_book_id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: book_authors
+            baseColumnNames: author_id
+            referencedTableName: authors
+            referencedColumnNames: id
+            constraintName: fk_book_authors_author_id
+            onDelete: CASCADE

--- a/src/main/resources/db/changelog/changes/16__publishers-schema.yaml
+++ b/src/main/resources/db/changelog/changes/16__publishers-schema.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 16__create-publishers-table
+      author: Jerael
+      comment: create publishers table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: publishers
+      changes:
+        - createTable:
+            tableName: publishers
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(500)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_publishers_name
+        - addPrimaryKey:
+            tableName: publishers
+            columnNames: id
+            constraintName: pk_publishers

--- a/src/main/resources/db/changelog/changes/17__languages-schema.yaml
+++ b/src/main/resources/db/changelog/changes/17__languages-schema.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 17__create-languages-table
+      author: Jerael
+      comment: create languages table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: languages
+      changes:
+        - createTable:
+            tableName: languages
+            columns:
+              - column:
+                  name: code
+                  type: varchar(2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: languages
+            columnNames: code
+            constraintName: pk_languages

--- a/src/main/resources/db/changelog/changes/18__languages-data.yaml
+++ b/src/main/resources/db/changelog/changes/18__languages-data.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 18__load-languages-data
+      author: Jerael
+      comment: insert seed data into languages table
+      preconditions:
+        - onFail: MARK_RAN
+          tableIsEmpty:
+            tableName: languages
+      changes:
+        - loadData:
+            tableName: languages
+            file: ../data/languages.csv
+            relativeToChangelogFile: true
+            columns:
+              - column:
+                  header: code
+                  name: code
+                  type: STRING
+              - column:
+                  header: name
+                  name: name
+                  type: STRING

--- a/src/main/resources/db/changelog/changes/19__notes-schema.yaml
+++ b/src/main/resources/db/changelog/changes/19__notes-schema.yaml
@@ -1,0 +1,67 @@
+databaseChangeLog:
+  - changeSet:
+      id: 19__create-notes-table
+      author: Jerael
+      comment: create notes table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: notes
+      changes:
+        - createTable:
+            tableName: notes
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: book_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: text_content
+                  type: text
+                  constraints:
+                    nullable: true
+              - column:
+                  name: file_name
+                  type: text
+                  constraints:
+                    nullable: true
+              - column:
+                  name: page_number
+                  type: integer
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: notes
+            columnNames: id
+            constraintName: pk_notes
+        - addForeignKeyConstraint:
+            baseTableName: notes
+            baseColumnNames: book_id
+            referencedTableName: books
+            referencedColumnNames: id
+            constraintName: fk_notes_book_id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_notes_book_id
+            using: btree
+            tableName: notes
+            columns:
+              - column:
+                  name: book_id

--- a/src/main/resources/db/changelog/changes/20__reading_attempts-schema.yaml
+++ b/src/main/resources/db/changelog/changes/20__reading_attempts-schema.yaml
@@ -1,0 +1,66 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20__create-reading_attempts-table
+      author: Jerael
+      comment: create reading_attempts table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: reading_attempts
+      changes:
+        - createTable:
+            tableName: reading_attempts
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: book_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: started_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+              - column:
+                  name: finished_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: reading_attempts
+            columnNames: id
+            constraintName: pk_reading_attempts
+        - addForeignKeyConstraint:
+            baseTableName: reading_attempts
+            baseColumnNames: book_id
+            referencedTableName: books
+            referencedColumnNames: id
+            constraintName: fk_reading_attempts_book_id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_reading_attempts_book_id
+            using: btree
+            tableName: reading_attempts
+            columns:
+              - column:
+                  name: book_id
+        - createIndex:
+            indexName: idx_reading_attempts_book_status
+            using: btree
+            tableName: reading_attempts
+            columns:
+              - column:
+                  name: book_id
+              - column:
+                  name: status

--- a/src/main/resources/db/changelog/changes/21__reading_sessions-schema.yaml
+++ b/src/main/resources/db/changelog/changes/21__reading_sessions-schema.yaml
@@ -1,0 +1,62 @@
+databaseChangeLog:
+  - changeSet:
+      id: 21__create-reading_sessions-table
+      author: Jerael
+      comment: create reading_sessions table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            tableExists:
+              tableName: reading_sessions
+      changes:
+        - createTable:
+            tableName: reading_sessions
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attempt_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_page
+                  type: integer
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_page
+                  type: integer
+                  constraints:
+                    nullable: false
+              - column:
+                  name: started_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+              - column:
+                  name: finished_at
+                  type: timestamp with time zone
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: reading_sessions
+            columnNames: id
+            constraintName: pk_reading_sessions
+        - addForeignKeyConstraint:
+            baseTableName: reading_sessions
+            baseColumnNames: attempt_id
+            referencedTableName: reading_attempts
+            referencedColumnNames: id
+            constraintName: fk_reading_sessions_attempt_id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_reading_sessions_attempt_id
+            using: btree
+            tableName: reading_sessions
+            columns:
+              - column:
+                  name: attempt_id

--- a/src/main/resources/db/changelog/changes/22__add-nullable-fields-to-books.yaml
+++ b/src/main/resources/db/changelog/changes/22__add-nullable-fields-to-books.yaml
@@ -1,0 +1,82 @@
+databaseChangeLog:
+  - changeSet:
+      id: 22__add-nullable-fields-to-books-table
+      author: Jerael
+      comment: add nullable fields to books table
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            columnExists:
+              tableName: books
+              columnName: description
+      changes:
+        - addColumn:
+            tableName: books
+            columns:
+              - column:
+                  name: description
+                  type: text
+                  constraints:
+                    nullable: true
+              - column:
+                  name: publisher_id
+                  type: uuid
+                  constraints:
+                    nullable: true
+              - column:
+                  name: language_code
+                  type: varchar(2)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: published_on
+                  type: date
+                  constraints:
+                    nullable: true
+              - column:
+                  name: total_pages
+                  type: integer
+                  constraints:
+                    nullable: true
+              - column:
+                  name: isbn_10
+                  type: varchar(10)
+                  constraints:
+                    nullable: true
+                    unique: true
+                    uniqueConstraintName: uq_books_isbn_10
+              - column:
+                  name: isbn_13
+                  type: varchar(13)
+                  constraints:
+                    nullable: true
+                    unique: true
+                    uniqueConstraintName: uq_books_isbn_13
+        - addForeignKeyConstraint:
+            baseTableName: books
+            baseColumnNames: publisher_id
+            referencedTableName: publishers
+            referencedColumnNames: id
+            constraintName: fk_books_publisher_id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: books
+            baseColumnNames: language_code
+            referencedTableName: languages
+            referencedColumnNames: code
+            constraintName: fk_books_language_code
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_books_publisher_id
+            using: btree
+            tableName: books
+            columns:
+              - column:
+                  name: publisher_id
+        - createIndex:
+            indexName: idx_books_language_code
+            using: btree
+            tableName: books
+            columns:
+              - column:
+                  name: language_code

--- a/src/main/resources/db/changelog/changes/23__set-finished_at-nullable-in-reading_attempts.yaml
+++ b/src/main/resources/db/changelog/changes/23__set-finished_at-nullable-in-reading_attempts.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 23__set-finished_at-nullable-in-reading_attempts
+      author: Jerael
+      comment: set finished_at nullable in reading_attempts
+      preconditions:
+        - onFail: HALT
+          columnExists:
+            tableName: reading_attempts
+            columnName: finished_at
+      changes:
+        - dropNotNullConstraint:
+            tableName: reading_attempts
+            columnName: finished_at
+            columnDataType: timestamp with time zone

--- a/src/main/resources/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml
+++ b/src/main/resources/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 24__set-finished_at-nullable-in-reading_sessions
+      author: Jerael
+      comment: set finished_at nullable in reading_sessions
+      preconditions:
+        - onFail: HALT
+          columnExists:
+            tableName: reading_sessions
+            columnName: finished_at
+      changes:
+        - dropNotNullConstraint:
+            tableName: reading_sessions
+            columnName: finished_at
+            columnDataType: timestamp with time zone

--- a/src/main/resources/db/changelog/changes/25__add-unknown-publisher-to-publishers.yaml
+++ b/src/main/resources/db/changelog/changes/25__add-unknown-publisher-to-publishers.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 25__add-unknown-publisher-to-publishers
+      author: Jerael
+      comment: add unknown publisher to publishers
+      preconditions:
+        - onFail: MARK_RAN
+          not:
+            sqlCheck:
+              expectedResult: 1
+              sql: SELECT COUNT(*) FROM publishers WHERE id = '85e0df25-5257-4e15-96e6-46a9c2e3bbfe'
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO publishers (id, name)
+              VALUES ('85e0df25-5257-4e15-96e6-46a9c2e3bbfe', 'Unknown Publisher');

--- a/src/main/resources/db/changelog/changes/26__migrate-authors.yaml
+++ b/src/main/resources/db/changelog/changes/26__migrate-authors.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 26__migrate-authors
+      author: Jerael
+      comment: migrate authors
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO authors (id, full_name)
+              SELECT gen_random_uuid(), author
+              FROM books
+              WHERE author <> '';

--- a/src/main/resources/db/changelog/changes/27__link-books-to-authors.yaml
+++ b/src/main/resources/db/changelog/changes/27__link-books-to-authors.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 27__link-books-to-authors
+      author: Jerael
+      comment: link books to authors
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO book_authors (book_id, author_id)
+              SELECT b.id, a.id
+              FROM books AS b
+              JOIN authors a ON b.author = a.full_name;

--- a/src/main/resources/db/changelog/changes/28__add-attempts-for-books-to-reading_attempts.yaml
+++ b/src/main/resources/db/changelog/changes/28__add-attempts-for-books-to-reading_attempts.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 28__add-attempts-for-books-to-reading_attempts
+      author: Jerael
+      comment: add attempts for books to reading_attempts
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO reading_attempts (id, book_id, status, started_at)
+              SELECT gen_random_uuid(), id, status, created_at
+              FROM books;

--- a/src/main/resources/db/changelog/changes/29__fill-publisher_id-and-language_code-in-books.yaml
+++ b/src/main/resources/db/changelog/changes/29__fill-publisher_id-and-language_code-in-books.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 29__fill-publisher_id-and-language_code-in-books
+      author: Jerael
+      comment: fill publisher_id and language_code in books
+      changes:
+        - sql:
+            sql: |
+              UPDATE books
+              SET
+                language_code = 'en',
+                publisher_id  = (
+                  SELECT id
+                  FROM publishers
+                  WHERE name = 'Unknown Publisher'
+                )
+              WHERE language_code IS NULL;

--- a/src/main/resources/db/changelog/data/languages.csv
+++ b/src/main/resources/db/changelog/data/languages.csv
@@ -1,0 +1,185 @@
+code,name
+aa,Afar
+ab,Аԥсшәа
+ae,Avesta
+af,Afrikaans
+ak,Akan
+am,አማርኛ
+an,Aragonés
+ar,العربية
+as,অসমীয়া
+av,Авар
+ay,Aymar
+az,Azərbaycanca
+ba,Башҡорт
+be,Беларуская
+bg,Български
+bh,भोजपुरी
+bi,Bislama
+bm,Bamanankan
+bn,বাংলা
+bo,བོད་ཡིག
+br,Brezhoneg
+bs,Bosanski
+ca,Català
+ce,Нохчийн
+ch,Chamoru
+co,Corsu
+cr,ᓀᐦᐃᔭᐍᐏᐣ
+cs,Čeština
+cu,Словѣньскъ
+cv,Чӑваш
+cy,Cymraeg
+da,Dansk
+de,Deutsch
+dv,ދިވެހި
+dz,རྫོང་ཁ
+ee,Eʋegbe
+el,Ελληνικά
+en,English
+eo,Esperanto
+es,Español
+et,Eesti
+eu,Euskara
+fa,فارسی
+ff,Fulfulde
+fi,Suomi
+fj,Vosa Vakaviti
+fo,Føroyskt
+fr,Français
+fy,Frysk
+ga,Gaeilge
+gd,Gàidhlig
+gl,Galego
+gn,Avañe'ẽ
+gu,ગુજરાતી
+gv,Gaelg
+ha,Hausa
+he,עברית
+hi,हिन्दी
+ho,Hiri Motu
+hr,Hrvatski
+ht,Kreyòl ayisyen
+hu,Magyar
+hy,Հայերեն
+hz,Oshiwambo
+ia,Interlingua
+id,Bahasa Indonesia
+ie,Interlingue
+ig,Igbo
+ii,ꆈꌠ꒿
+ik,Iñupiaq
+io,Ido
+is,Íslenska
+it,Italiano
+iu,ᐃᓄᒃᑎᑐᑦ
+ja,日本語
+jv,Basa Jawa
+ka,ქართული
+kg,Kikongo
+ki,Gĩkũyũ
+kj,Kuanyama
+kk,Қазақша
+kl,Kalaallit
+km,ខ្មែរ
+kn,ಕನ್ನಡ
+ko,한국어
+kr,Kanuri
+ks,कश्मीरी
+ku,Kurdî
+kv,Коми
+kw,Kernewek
+ky,Кыргызча
+la,Latina
+lb,Lëtzebuergesch
+lg,Luganda
+li,Limburgs
+ln,Lingála
+lo,ລາວ
+lt,Lietuvių
+lu,Tshiluba
+lv,Latviešu
+mg,Malagasy
+mh,Marshallese
+mi,Te Reo Māori
+mk,Македонски
+ml,മലയാളം
+mn,Монгол
+mr,मराठी
+ms,Bahasa Melayu
+mt,Malti
+my,မြန်မာ
+na,Nauru
+nb,Norsk bokmål
+nd,IsiNdebele
+ne,नेपाली
+ng,Owambo
+nl,Nederlands
+nn,Norsk nynorsk
+no,Norsk
+nr,IsiNdebele
+nv,Diné bizaad
+ny,Chichewa
+oc,Occitan
+oj,ᐊᓂᔑᓈᐯᒧᐎᓐ
+om,Oromoo
+or,ଓଡ଼ିଆ
+os,Ирон
+pa,ਪੰਜਾਬੀ
+pi,पालि
+pl,Polski
+ps,پښتو
+pt,Português
+qu,Runa Simi
+rm,Rumantsch
+rn,Kirundi
+ro,Română
+ru,Русский
+rw,Kinyarwanda
+sa,संस्कृतम्
+sc,Sardu
+sd,سنڌي
+se,Sámegiella
+sg,Sängö
+si,සිංහල
+sk,Slovenčina
+sl,Slovenščina
+sm,Gagana Samoa
+sn,ChiShona
+so,Soomaaliga
+sq,Shqip
+sr,Српски
+ss,SiSwati
+st,Sesotho
+su,Basa Sunda
+sv,Svenska
+sw,Kiswahili
+ta,தமிழ்
+te,తెలుగు
+tg,Тоҷикӣ
+th,ไทย
+ti,ትግርኛ
+tk,Türkmençe
+tl,Tagalog
+tn,Setswana
+to,Lea faka-Tonga
+tr,Türkçe
+ts,Tsonga
+tt,Татарча
+tw,Twi
+ty,Reo Tahiti
+ug,Uyghurche
+uk,Українська
+ur,اردو
+uz,Oʻzbekcha
+ve,Tshivenda
+vi,Tiếng Việt
+vo,Volapük
+wa,Walon
+wo,Wolof
+xh,isiXhosa
+yi,ייִדיש
+yo,Yorùbá
+za,Saɯ cueŋƅ
+zh,中文
+zu,isiZulu

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -21,3 +21,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/11__email_verifications-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/12__refresh_tokens-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/13__rename-book_id-field-and-update-fk.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -23,3 +23,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/12__refresh_tokens-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/13__rename-book_id-field-and-update-fk.yaml
+  - include:
+      file: classpath:/db/changelog/changes/14__authors-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/15__book_authors-schema.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -33,3 +33,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/17__languages-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/19__notes-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/20__reading_attempts-schema.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -37,3 +37,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/20__reading_attempts-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/21__reading_sessions-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/22__add-nullable-fields-to-books.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -31,3 +31,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/16__publishers-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/17__languages-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/19__notes-schema.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -39,3 +39,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/21__reading_sessions-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/22__add-nullable-fields-to-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/23__set-finished_at-nullable-in-reading_attempts.yaml
+  - include:
+      file: classpath:/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -35,3 +35,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/19__notes-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/20__reading_attempts-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/21__reading_sessions-schema.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -29,3 +29,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/15__book_authors-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/16__publishers-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/17__languages-schema.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -27,3 +27,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/14__authors-schema.yaml
   - include:
       file: classpath:/db/changelog/changes/15__book_authors-schema.yaml
+  - include:
+      file: classpath:/db/changelog/changes/16__publishers-schema.yaml


### PR DESCRIPTION
### What does this PR do?

- Renamed `book_id` field to `id` in `books` table and update foreign key in `book_genres`.
- Added migrations for `authors`, `book_authors`, `publishers`, `languages`, `notes`, `reading_attempts` and `reading_sessions` tables.
- Added seed data for `languages` table.
- Added migration for new fields in `books` table.
- Added scripts to migrate existing book data into the new structure without data loss.

### Related tickets

Part of #113

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
