### PR TITLE
feat: infrastructure for new tables

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -11,4 +11,5 @@ public class Tables {
     public final String EMAIL_VERIFICATIONS = "email_verifications";
     public final String REFRESH_TOKENS = "refresh_tokens";
     public final String AUTHORS = "authors";
+    public final String PUBLISHERS = "publishers";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -13,4 +13,5 @@ public class Tables {
     public final String AUTHORS = "authors";
     public final String PUBLISHERS = "publishers";
     public final String LANGUAGES = "languages";
+    public final String NOTES = "notes";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -14,4 +14,5 @@ public class Tables {
     public final String PUBLISHERS = "publishers";
     public final String LANGUAGES = "languages";
     public final String NOTES = "notes";
+    public final String READING_ATTEMPTS = "reading_attempts";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -15,4 +15,5 @@ public class Tables {
     public final String LANGUAGES = "languages";
     public final String NOTES = "notes";
     public final String READING_ATTEMPTS = "reading_attempts";
+    public final String READING_SESSIONS = "reading_sessions";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -10,4 +10,5 @@ public class Tables {
     public final String USERS = "users";
     public final String EMAIL_VERIFICATIONS = "email_verifications";
     public final String REFRESH_TOKENS = "refresh_tokens";
+    public final String AUTHORS = "authors";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -12,4 +12,5 @@ public class Tables {
     public final String REFRESH_TOKENS = "refresh_tokens";
     public final String AUTHORS = "authors";
     public final String PUBLISHERS = "publishers";
+    public final String LANGUAGES = "languages";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/AuthorEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/AuthorEntity.java
@@ -1,0 +1,23 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import java.util.UUID;
+
+@Table(name = Tables.AUTHORS)
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class AuthorEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "full_name")
+    private String fullName;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/AuthorEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/AuthorEntity.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.AuthorRules;
 import java.util.UUID;
 
 @Table(name = Tables.AUTHORS)
@@ -18,6 +19,6 @@ public class AuthorEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(name = "full_name")
+    @Column(name = "full_name", length = AuthorRules.AUTHOR_FULL_NAME_MAX_LENGTH, nullable = false)
     private String fullName;
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/LanguageEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/LanguageEntity.java
@@ -1,0 +1,25 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.LanguageRules;
+
+@Table(name = Tables.LANGUAGES)
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class LanguageEntity {
+    @Id
+    @Column(name = "code", length = LanguageRules.LANGUAGE_CODE_LENGTH, nullable = false)
+    private String code;
+
+    @Column(name = "name", length = LanguageRules.LANGUAGE_NAME_MAX_LENGTH, nullable = false)
+    private String name;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/NoteEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/NoteEntity.java
@@ -1,0 +1,43 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.NoteRules;
+import ru.jerael.booktracker.backend.domain.model.note.NoteType;
+import java.time.Instant;
+import java.util.UUID;
+
+@Table(name = Tables.NOTES)
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class NoteEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private BookEntity book;
+
+    @Column(name = "type", length = NoteRules.NOTE_TYPE_MAX_LENGTH, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NoteType type;
+
+    @Column(name = "text_content", length = NoteRules.NOTE_TEXT_CONTENT_MAX_LENGTH)
+    private String textContent;
+
+    @Column(name = "file_name")
+    private String fileName;
+
+    @Column(name = "page_number", nullable = false)
+    private int pageNumber;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/PublisherEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/PublisherEntity.java
@@ -1,0 +1,24 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.PublisherRules;
+import java.util.UUID;
+
+@Table(name = Tables.PUBLISHERS)
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class PublisherEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "name", length = PublisherRules.PUBLISHER_NAME_MAX_LENGTH, nullable = false)
+    private String name;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/ReadingAttemptEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/ReadingAttemptEntity.java
@@ -8,6 +8,8 @@ import ru.jerael.booktracker.backend.data.db.constant.Tables;
 import ru.jerael.booktracker.backend.domain.constant.ReadingAttemptRules;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Table(name = Tables.READING_ATTEMPTS)
@@ -34,4 +36,12 @@ public class ReadingAttemptEntity {
 
     @Column(name = "finished_at")
     private Instant finishedAt;
+
+    @OneToMany(
+        mappedBy = "readingAttempt",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
+    )
+    private List<ReadingSessionEntity> sessions = new ArrayList<>();
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/ReadingAttemptEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/ReadingAttemptEntity.java
@@ -1,0 +1,37 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import ru.jerael.booktracker.backend.domain.constant.ReadingAttemptRules;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+@Table(name = Tables.READING_ATTEMPTS)
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class ReadingAttemptEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private BookEntity book;
+
+    @Column(name = "status", length = ReadingAttemptRules.STATUS_MAX_LENGTH, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BookStatus status;
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "finished_at")
+    private Instant finishedAt;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/ReadingSessionEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/ReadingSessionEntity.java
@@ -1,0 +1,37 @@
+package ru.jerael.booktracker.backend.data.db.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ru.jerael.booktracker.backend.data.db.constant.Tables;
+import java.time.Instant;
+import java.util.UUID;
+
+@Table(name = Tables.READING_SESSIONS)
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class ReadingSessionEntity {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attempt_id", nullable = false)
+    private ReadingAttemptEntity readingAttempt;
+
+    @Column(name = "start_page", nullable = false)
+    private int startPage;
+
+    @Column(name = "end_page", nullable = false)
+    private int endPage;
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "finished_at", nullable = false)
+    private Instant finishedAt;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaAuthorRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaAuthorRepository.java
@@ -1,0 +1,12 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface JpaAuthorRepository extends JpaRepository<AuthorEntity, UUID> {
+    Optional<AuthorEntity> findByFullNameIgnoreCase(String fullName);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaLanguageRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaLanguageRepository.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.LanguageEntity;
+import java.util.Optional;
+
+@Repository
+public interface JpaLanguageRepository extends JpaRepository<LanguageEntity, String> {
+    Optional<LanguageEntity> findByCode(String code);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaNoteRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaNoteRepository.java
@@ -1,0 +1,12 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface JpaNoteRepository extends JpaRepository<NoteEntity, UUID> {
+    List<NoteEntity> findAllByBookId(UUID bookId);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaPublisherRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaPublisherRepository.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaPublisherRepository extends JpaRepository<PublisherEntity, UUID> {
+    Optional<PublisherEntity> findByNameIgnoreCase(String name);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaReadingAttemptRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaReadingAttemptRepository.java
@@ -1,0 +1,15 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface JpaReadingAttemptRepository extends JpaRepository<ReadingAttemptEntity, UUID> {
+    List<ReadingAttemptEntity> findAllByBookId(UUID bookId);
+
+    List<ReadingAttemptEntity> findAllByBookIdAndStatus(UUID bookId, BookStatus status);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaReadingSessionRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaReadingSessionRepository.java
@@ -1,0 +1,12 @@
+package ru.jerael.booktracker.backend.data.db.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingSessionEntity;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface JpaReadingSessionRepository extends JpaRepository<ReadingSessionEntity, UUID> {
+    List<ReadingSessionEntity> findAllByReadingAttemptId(UUID attemptId);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/AuthorDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/AuthorDataMapper.java
@@ -1,0 +1,26 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+
+@Component
+public class AuthorDataMapper {
+    public AuthorEntity toEntity(Author author) {
+        if (author == null) return null;
+
+        AuthorEntity entity = new AuthorEntity();
+        entity.setId(author.id());
+        entity.setFullName(author.fullName());
+        return entity;
+    }
+
+    public Author toDomain(AuthorEntity entity) {
+        if (entity == null) return null;
+
+        return new Author(
+            entity.getId(),
+            entity.getFullName()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/LanguageDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/LanguageDataMapper.java
@@ -1,0 +1,17 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.LanguageEntity;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+
+@Component
+public class LanguageDataMapper {
+    public Language toDomain(LanguageEntity entity) {
+        if (entity == null) return null;
+
+        return new Language(
+            entity.getCode(),
+            entity.getName()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapper.java
@@ -1,0 +1,39 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+
+@Component
+public class NoteDataMapper {
+    public NoteEntity toEntity(Note note) {
+        if (note == null) return null;
+
+        NoteEntity entity = new NoteEntity();
+        entity.setId(note.id());
+        BookEntity book = new BookEntity();
+        book.setId(note.bookId());
+        entity.setBook(book);
+        entity.setType(note.type());
+        entity.setTextContent(note.textContent());
+        entity.setFileName(note.fileName());
+        entity.setPageNumber(note.pageNumber());
+        entity.setCreatedAt(note.createdAt());
+        return entity;
+    }
+
+    public Note toDomain(NoteEntity entity) {
+        if (entity == null) return null;
+
+        return new Note(
+            entity.getId(),
+            entity.getBook().getId(),
+            entity.getType(),
+            entity.getTextContent(),
+            entity.getFileName(),
+            entity.getPageNumber(),
+            entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/PublisherDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/PublisherDataMapper.java
@@ -1,0 +1,26 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+
+@Component
+public class PublisherDataMapper {
+    public PublisherEntity toEntity(Publisher publisher) {
+        if (publisher == null) return null;
+
+        PublisherEntity entity = new PublisherEntity();
+        entity.setId(publisher.id());
+        entity.setName(publisher.name());
+        return entity;
+    }
+
+    public Publisher toDomain(PublisherEntity entity) {
+        if (entity == null) return null;
+
+        return new Publisher(
+            entity.getId(),
+            entity.getName()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapper.java
@@ -1,0 +1,37 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+
+@Component
+public class ReadingAttemptDataMapper {
+    public ReadingAttemptEntity toEntity(ReadingAttempt readingAttempt) {
+        if (readingAttempt == null) return null;
+
+        ReadingAttemptEntity entity = new ReadingAttemptEntity();
+        entity.setId(readingAttempt.id());
+
+        BookEntity bookEntity = new BookEntity();
+        bookEntity.setId(readingAttempt.bookId());
+        entity.setBook(bookEntity);
+
+        entity.setStatus(readingAttempt.status());
+        entity.setStartedAt(readingAttempt.startedAt());
+        entity.setFinishedAt(readingAttempt.finishedAt());
+        return entity;
+    }
+
+    public ReadingAttempt toDomain(ReadingAttemptEntity entity) {
+        if (entity == null) return null;
+
+        return new ReadingAttempt(
+            entity.getId(),
+            entity.getBook().getId(),
+            entity.getStatus(),
+            entity.getStartedAt(),
+            entity.getFinishedAt()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapper.java
@@ -1,12 +1,18 @@
 package ru.jerael.booktracker.backend.data.mapper;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingSessionEntity;
 import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class ReadingAttemptDataMapper {
+    private final ReadingSessionDataMapper readingSessionDataMapper;
+
     public ReadingAttemptEntity toEntity(ReadingAttempt readingAttempt) {
         if (readingAttempt == null) return null;
 
@@ -20,6 +26,19 @@ public class ReadingAttemptDataMapper {
         entity.setStatus(readingAttempt.status());
         entity.setStartedAt(readingAttempt.startedAt());
         entity.setFinishedAt(readingAttempt.finishedAt());
+
+        if (readingAttempt.sessions() != null) {
+            entity.setSessions(
+                readingAttempt.sessions().stream()
+                    .map(readingSession -> {
+                        ReadingSessionEntity sessionEntity = readingSessionDataMapper.toEntity(readingSession);
+                        sessionEntity.setReadingAttempt(entity);
+                        return sessionEntity;
+                    })
+                    .collect(Collectors.toList())
+            );
+        }
+
         return entity;
     }
 
@@ -31,7 +50,8 @@ public class ReadingAttemptDataMapper {
             entity.getBook().getId(),
             entity.getStatus(),
             entity.getStartedAt(),
-            entity.getFinishedAt()
+            entity.getFinishedAt(),
+            entity.getSessions().stream().map(readingSessionDataMapper::toDomain).toList()
         );
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/ReadingSessionDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/ReadingSessionDataMapper.java
@@ -1,0 +1,39 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingSessionEntity;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
+
+@Component
+public class ReadingSessionDataMapper {
+    public ReadingSessionEntity toEntity(ReadingSession readingSession) {
+        if (readingSession == null) return null;
+
+        ReadingSessionEntity entity = new ReadingSessionEntity();
+        entity.setId(readingSession.id());
+
+        ReadingAttemptEntity readingAttempt = new ReadingAttemptEntity();
+        readingAttempt.setId(readingSession.attemptId());
+        entity.setReadingAttempt(readingAttempt);
+
+        entity.setStartPage(readingSession.startPage());
+        entity.setEndPage(readingSession.endPage());
+        entity.setStartedAt(readingSession.startedAt());
+        entity.setFinishedAt(readingSession.finishedAt());
+        return entity;
+    }
+
+    public ReadingSession toDomain(ReadingSessionEntity entity) {
+        if (entity == null) return null;
+
+        return new ReadingSession(
+            entity.getId(),
+            entity.getReadingAttempt().getId(),
+            entity.getStartPage(),
+            entity.getEndPage(),
+            entity.getStartedAt(),
+            entity.getFinishedAt()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImpl.java
@@ -1,0 +1,29 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaAuthorRepository;
+import ru.jerael.booktracker.backend.data.mapper.AuthorDataMapper;
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import ru.jerael.booktracker.backend.domain.repository.AuthorRepository;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthorRepositoryImpl implements AuthorRepository {
+    private final JpaAuthorRepository jpaAuthorRepository;
+    private final AuthorDataMapper authorDataMapper;
+
+    @Override
+    public Optional<Author> findByFullName(String fullName) {
+        return jpaAuthorRepository.findByFullNameIgnoreCase(fullName).map(authorDataMapper::toDomain);
+    }
+
+    @Override
+    public Author save(Author author) {
+        AuthorEntity entity = authorDataMapper.toEntity(author);
+        AuthorEntity savedEntity = jpaAuthorRepository.save(entity);
+        return authorDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
@@ -1,0 +1,27 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaLanguageRepository;
+import ru.jerael.booktracker.backend.data.mapper.LanguageDataMapper;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.repository.LanguageRepository;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LanguageRepositoryImpl implements LanguageRepository {
+    private final JpaLanguageRepository jpaLanguageRepository;
+    private final LanguageDataMapper languageDataMapper;
+
+    @Override
+    public List<Language> findAll() {
+        return jpaLanguageRepository.findAll().stream().map(languageDataMapper::toDomain).toList();
+    }
+
+    @Override
+    public Optional<Language> findByCode(String code) {
+        return jpaLanguageRepository.findByCode(code).map(languageDataMapper::toDomain);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImpl.java
@@ -1,0 +1,30 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaNoteRepository;
+import ru.jerael.booktracker.backend.data.mapper.NoteDataMapper;
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+import ru.jerael.booktracker.backend.domain.repository.NoteRepository;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class NoteRepositoryImpl implements NoteRepository {
+    private final JpaNoteRepository jpaNoteRepository;
+    private final NoteDataMapper noteDataMapper;
+
+    @Override
+    public List<Note> findAllByBookId(UUID bookId) {
+        return jpaNoteRepository.findAllByBookId(bookId).stream().map(noteDataMapper::toDomain).toList();
+    }
+
+    @Override
+    public Note save(Note note) {
+        NoteEntity entity = noteDataMapper.toEntity(note);
+        NoteEntity savedEntity = jpaNoteRepository.save(entity);
+        return noteDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImpl.java
@@ -1,0 +1,29 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaPublisherRepository;
+import ru.jerael.booktracker.backend.data.mapper.PublisherDataMapper;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import ru.jerael.booktracker.backend.domain.repository.PublisherRepository;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PublisherRepositoryImpl implements PublisherRepository {
+    private final JpaPublisherRepository jpaPublisherRepository;
+    private final PublisherDataMapper publisherDataMapper;
+
+    @Override
+    public Optional<Publisher> findByName(String name) {
+        return jpaPublisherRepository.findByNameIgnoreCase(name).map(publisherDataMapper::toDomain);
+    }
+
+    @Override
+    public Publisher save(Publisher publisher) {
+        PublisherEntity entity = publisherDataMapper.toEntity(publisher);
+        PublisherEntity savedEntity = jpaPublisherRepository.save(entity);
+        return publisherDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImpl.java
@@ -1,0 +1,38 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaReadingAttemptRepository;
+import ru.jerael.booktracker.backend.data.mapper.ReadingAttemptDataMapper;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import ru.jerael.booktracker.backend.domain.repository.ReadingAttemptRepository;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ReadingAttemptRepositoryImpl implements ReadingAttemptRepository {
+    private final JpaReadingAttemptRepository jpaReadingAttemptRepository;
+    private final ReadingAttemptDataMapper readingAttemptDataMapper;
+
+    @Override
+    public List<ReadingAttempt> findAllByBookId(UUID bookId) {
+        return jpaReadingAttemptRepository.findAllByBookId(bookId).stream().map(readingAttemptDataMapper::toDomain)
+            .toList();
+    }
+
+    @Override
+    public List<ReadingAttempt> findAllByBookIdAndStatus(UUID bookId, BookStatus status) {
+        return jpaReadingAttemptRepository.findAllByBookIdAndStatus(bookId, status).stream()
+            .map(readingAttemptDataMapper::toDomain).toList();
+    }
+
+    @Override
+    public ReadingAttempt save(ReadingAttempt readingAttempt) {
+        ReadingAttemptEntity entity = readingAttemptDataMapper.toEntity(readingAttempt);
+        ReadingAttemptEntity savedEntity = jpaReadingAttemptRepository.save(entity);
+        return readingAttemptDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImpl.java
@@ -1,0 +1,31 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingSessionEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaReadingSessionRepository;
+import ru.jerael.booktracker.backend.data.mapper.ReadingSessionDataMapper;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
+import ru.jerael.booktracker.backend.domain.repository.ReadingSessionRepository;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ReadingSessionRepositoryImpl implements ReadingSessionRepository {
+    private final JpaReadingSessionRepository jpaReadingSessionRepository;
+    private final ReadingSessionDataMapper readingSessionDataMapper;
+
+    @Override
+    public List<ReadingSession> findAllByAttemptId(UUID attemptId) {
+        return jpaReadingSessionRepository.findAllByReadingAttemptId(attemptId).stream()
+            .map(readingSessionDataMapper::toDomain).toList();
+    }
+
+    @Override
+    public ReadingSession save(ReadingSession readingSession) {
+        ReadingSessionEntity entity = readingSessionDataMapper.toEntity(readingSession);
+        ReadingSessionEntity savedEntity = jpaReadingSessionRepository.save(entity);
+        return readingSessionDataMapper.toDomain(savedEntity);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/AuthorRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/AuthorRules.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class AuthorRules {
+    private AuthorRules() {}
+
+    public static final int AUTHOR_FULL_NAME_MAX_LENGTH = 500;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/LanguageRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/LanguageRules.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class LanguageRules {
+    private LanguageRules() {}
+
+    public static final int LANGUAGE_CODE_LENGTH = 2;
+    public static final int LANGUAGE_NAME_MAX_LENGTH = 100;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/NoteRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/NoteRules.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class NoteRules {
+    private NoteRules() {}
+
+    public static final int NOTE_TYPE_MAX_LENGTH = 100;
+    public static final int NOTE_TEXT_CONTENT_MAX_LENGTH = 5000;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/PublisherRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/PublisherRules.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class PublisherRules {
+    private PublisherRules() {}
+
+    public static final int PUBLISHER_NAME_MAX_LENGTH = 500;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/ReadingAttemptRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/ReadingAttemptRules.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.constant;
+
+public final class ReadingAttemptRules {
+    private ReadingAttemptRules() {}
+
+    public static final int STATUS_MAX_LENGTH = 100;
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/author/Author.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/author/Author.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.model.author;
+
+import java.util.UUID;
+
+public record Author(
+    UUID id,
+    String fullName
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/language/Language.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/language/Language.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.domain.model.language;
+
+public record Language(
+    String code,
+    String name
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/note/Note.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/note/Note.java
@@ -1,0 +1,15 @@
+package ru.jerael.booktracker.backend.domain.model.note;
+
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record Note(
+    UUID id,
+    UUID bookId,
+    NoteType type,
+    @Nullable String textContent,
+    @Nullable String fileName,
+    int pageNumber,
+    Instant createdAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/note/NoteType.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/note/NoteType.java
@@ -1,0 +1,5 @@
+package ru.jerael.booktracker.backend.domain.model.note;
+
+public enum NoteType {
+    TEXT, IMAGE, AUDIO, VIDEO
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/publisher/Publisher.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/publisher/Publisher.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.model.publisher;
+
+import java.util.UUID;
+
+public record Publisher(
+    UUID id,
+    String name
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_attempt/ReadingAttempt.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_attempt/ReadingAttempt.java
@@ -1,0 +1,14 @@
+package ru.jerael.booktracker.backend.domain.model.reading_attempt;
+
+import jakarta.annotation.Nullable;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReadingAttempt(
+    UUID id,
+    UUID bookId,
+    BookStatus status,
+    Instant startedAt,
+    @Nullable Instant finishedAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_attempt/ReadingAttempt.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_attempt/ReadingAttempt.java
@@ -2,7 +2,9 @@ package ru.jerael.booktracker.backend.domain.model.reading_attempt;
 
 import jakarta.annotation.Nullable;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public record ReadingAttempt(
@@ -10,5 +12,6 @@ public record ReadingAttempt(
     UUID bookId,
     BookStatus status,
     Instant startedAt,
-    @Nullable Instant finishedAt
+    @Nullable Instant finishedAt,
+    List<ReadingSession> sessions
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_session/ReadingSession.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_session/ReadingSession.java
@@ -1,0 +1,13 @@
+package ru.jerael.booktracker.backend.domain.model.reading_session;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReadingSession(
+    UUID id,
+    UUID attemptId,
+    int startPage,
+    int endPage,
+    Instant startedAt,
+    Instant finishedAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/AuthorRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/AuthorRepository.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import java.util.Optional;
+
+public interface AuthorRepository {
+    Optional<Author> findByFullName(String fullName);
+
+    Author save(Author author);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/LanguageRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/LanguageRepository.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import java.util.List;
+import java.util.Optional;
+
+public interface LanguageRepository {
+    List<Language> findAll();
+
+    Optional<Language> findByCode(String code);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/NoteRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/NoteRepository.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+import java.util.List;
+import java.util.UUID;
+
+public interface NoteRepository {
+    List<Note> findAllByBookId(UUID bookId);
+
+    Note save(Note note);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/PublisherRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/PublisherRepository.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import java.util.Optional;
+
+public interface PublisherRepository {
+    Optional<Publisher> findByName(String name);
+
+    Publisher save(Publisher publisher);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/ReadingAttemptRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/ReadingAttemptRepository.java
@@ -1,0 +1,14 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import java.util.List;
+import java.util.UUID;
+
+public interface ReadingAttemptRepository {
+    List<ReadingAttempt> findAllByBookId(UUID bookId);
+
+    List<ReadingAttempt> findAllByBookIdAndStatus(UUID bookId, BookStatus status);
+
+    ReadingAttempt save(ReadingAttempt readingAttempt);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/ReadingSessionRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/ReadingSessionRepository.java
@@ -1,0 +1,11 @@
+package ru.jerael.booktracker.backend.domain.repository;
+
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
+import java.util.List;
+import java.util.UUID;
+
+public interface ReadingSessionRepository {
+    List<ReadingSession> findAllByAttemptId(UUID attemptId);
+
+    ReadingSession save(ReadingSession readingSession);
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/AuthorDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/AuthorDataMapperTest.java
@@ -1,0 +1,36 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthorDataMapperTest {
+    private final AuthorDataMapper authorDataMapper = new AuthorDataMapper();
+
+    private final UUID id = UUID.fromString("afe42b20-8148-457e-9c97-8c4db85a71a9");
+    private final String fullName = "Full Name";
+
+    @Test
+    void toEntity() {
+        Author author = new Author(id, fullName);
+
+        AuthorEntity entity = authorDataMapper.toEntity(author);
+
+        assertEquals(id, entity.getId());
+        assertEquals(fullName, entity.getFullName());
+    }
+
+    @Test
+    void toDomain() {
+        AuthorEntity entity = new AuthorEntity();
+        entity.setId(id);
+        entity.setFullName(fullName);
+
+        Author author = authorDataMapper.toDomain(entity);
+
+        assertEquals(id, author.id());
+        assertEquals(fullName, author.fullName());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/LanguageDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/LanguageDataMapperTest.java
@@ -1,0 +1,25 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.LanguageEntity;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LanguageDataMapperTest {
+    private final LanguageDataMapper languageDataMapper = new LanguageDataMapper();
+
+    private final String code = "en";
+    private final String name = "English";
+
+    @Test
+    void toDomain() {
+        LanguageEntity entity = new LanguageEntity();
+        entity.setCode(code);
+        entity.setName(name);
+
+        Language result = languageDataMapper.toDomain(entity);
+
+        assertEquals(code, result.code());
+        assertEquals(name, result.name());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapperTest.java
@@ -1,0 +1,72 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+import ru.jerael.booktracker.backend.domain.model.note.NoteType;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NoteDataMapperTest {
+    private final NoteDataMapper noteDataMapper = new NoteDataMapper();
+
+    private final UUID id = UUID.fromString("a774501c-002b-4420-8788-6f9828b4b419");
+    private final UUID bookId = UUID.fromString("cb1285f1-9084-4e3b-a7ed-9cb62699f930");
+    private final UUID userId = UUID.fromString("ee21a506-2e0c-4689-a341-ee66654387a3");
+    private final NoteType type = NoteType.TEXT;
+    private final String textContent = "text content";
+    private final String fileName = "file_name.txt";
+    private final int pageNumber = 123;
+    private final Instant createdAt = Instant.ofEpochMilli(1773826150059L);
+
+    @Test
+    void toEntity() {
+        Note note = new Note(id, bookId, type, textContent, fileName, pageNumber, createdAt);
+
+        NoteEntity result = noteDataMapper.toEntity(note);
+
+        assertEquals(id, result.getId());
+        assertEquals(bookId, result.getBook().getId());
+        assertEquals(type, result.getType());
+        assertEquals(textContent, result.getTextContent());
+        assertEquals(fileName, result.getFileName());
+        assertEquals(pageNumber, result.getPageNumber());
+        assertEquals(createdAt, result.getCreatedAt());
+    }
+
+    @Test
+    void toDomain() {
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        book.setUserId(userId);
+        book.setTitle("title");
+        book.setAuthor("author");
+        book.setCoverFileName(null);
+        book.setStatus(BookStatus.WANT_TO_READ);
+        book.setCreatedAt(Instant.now());
+        book.setGenres(Collections.emptySet());
+
+        NoteEntity entity = new NoteEntity();
+        entity.setId(id);
+        entity.setBook(book);
+        entity.setType(type);
+        entity.setTextContent(textContent);
+        entity.setFileName(fileName);
+        entity.setPageNumber(pageNumber);
+        entity.setCreatedAt(createdAt);
+
+        Note result = noteDataMapper.toDomain(entity);
+
+        assertEquals(id, result.id());
+        assertEquals(bookId, result.bookId());
+        assertEquals(type, result.type());
+        assertEquals(textContent, result.textContent());
+        assertEquals(fileName, result.fileName());
+        assertEquals(pageNumber, result.pageNumber());
+        assertEquals(createdAt, result.createdAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/PublisherDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/PublisherDataMapperTest.java
@@ -1,0 +1,36 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PublisherDataMapperTest {
+    private final PublisherDataMapper publisherDataMapper = new PublisherDataMapper();
+
+    private final UUID id = UUID.fromString("a95f2c31-acd2-4413-83ea-c775d6cda257");
+    private final String name = "Publisher Name";
+
+    @Test
+    void toEntity() {
+        Publisher publisher = new Publisher(id, name);
+
+        PublisherEntity entity = publisherDataMapper.toEntity(publisher);
+
+        assertEquals(id, entity.getId());
+        assertEquals(name, entity.getName());
+    }
+
+    @Test
+    void toDomain() {
+        PublisherEntity entity = new PublisherEntity();
+        entity.setId(id);
+        entity.setName(name);
+
+        Publisher publisher = publisherDataMapper.toDomain(entity);
+
+        assertEquals(id, publisher.id());
+        assertEquals(name, publisher.name());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
@@ -5,13 +5,17 @@ import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReadingAttemptDataMapperTest {
-    private final ReadingAttemptDataMapper readingAttemptDataMapper = new ReadingAttemptDataMapper();
+    private final ReadingSessionDataMapper readingSessionDataMapper = new ReadingSessionDataMapper();
+    private final ReadingAttemptDataMapper readingAttemptDataMapper =
+        new ReadingAttemptDataMapper(readingSessionDataMapper);
 
     private final UUID userId = UUID.fromString("57702775-4f01-4849-97e5-8c7456e01b5b");
     private final UUID id = UUID.fromString("4f38de27-b492-4b27-96ea-32331bc82598");
@@ -19,10 +23,14 @@ class ReadingAttemptDataMapperTest {
     private final BookStatus status = BookStatus.READING;
     private final Instant startedAt = Instant.now().minusSeconds(1000);
     private final Instant finishedAt = Instant.now();
+    private final List<ReadingSession> sessions = List.of(
+        new ReadingSession(UUID.randomUUID(), id, 5, 10, startedAt, finishedAt),
+        new ReadingSession(UUID.randomUUID(), id, 15, 20, startedAt, finishedAt)
+    );
 
     @Test
     void toEntity() {
-        ReadingAttempt readingAttempt = new ReadingAttempt(id, bookId, status, startedAt, finishedAt);
+        ReadingAttempt readingAttempt = new ReadingAttempt(id, bookId, status, startedAt, finishedAt, sessions);
 
         ReadingAttemptEntity entity = readingAttemptDataMapper.toEntity(readingAttempt);
 
@@ -31,6 +39,7 @@ class ReadingAttemptDataMapperTest {
         assertEquals(status, entity.getStatus());
         assertEquals(startedAt, entity.getStartedAt());
         assertEquals(finishedAt, entity.getFinishedAt());
+        assertEquals(2, entity.getSessions().size());
     }
 
     @Test
@@ -51,6 +60,7 @@ class ReadingAttemptDataMapperTest {
         entity.setStatus(status);
         entity.setStartedAt(startedAt);
         entity.setFinishedAt(finishedAt);
+        entity.setSessions(sessions.stream().map(readingSessionDataMapper::toEntity).toList());
 
         ReadingAttempt result = readingAttemptDataMapper.toDomain(entity);
 
@@ -59,5 +69,6 @@ class ReadingAttemptDataMapperTest {
         assertEquals(status, result.status());
         assertEquals(startedAt, result.startedAt());
         assertEquals(finishedAt, result.finishedAt());
+        assertEquals(2, result.sessions().size());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
@@ -1,0 +1,63 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReadingAttemptDataMapperTest {
+    private final ReadingAttemptDataMapper readingAttemptDataMapper = new ReadingAttemptDataMapper();
+
+    private final UUID userId = UUID.fromString("57702775-4f01-4849-97e5-8c7456e01b5b");
+    private final UUID id = UUID.fromString("4f38de27-b492-4b27-96ea-32331bc82598");
+    private final UUID bookId = UUID.fromString("baf246c3-5f17-495f-a8be-f724dcc8d485");
+    private final BookStatus status = BookStatus.READING;
+    private final Instant startedAt = Instant.now().minusSeconds(1000);
+    private final Instant finishedAt = Instant.now();
+
+    @Test
+    void toEntity() {
+        ReadingAttempt readingAttempt = new ReadingAttempt(id, bookId, status, startedAt, finishedAt);
+
+        ReadingAttemptEntity entity = readingAttemptDataMapper.toEntity(readingAttempt);
+
+        assertEquals(id, entity.getId());
+        assertEquals(bookId, entity.getBook().getId());
+        assertEquals(status, entity.getStatus());
+        assertEquals(startedAt, entity.getStartedAt());
+        assertEquals(finishedAt, entity.getFinishedAt());
+    }
+
+    @Test
+    void toDomain() {
+        BookEntity book = new BookEntity();
+        book.setId(bookId);
+        book.setUserId(userId);
+        book.setTitle("title");
+        book.setAuthor("author");
+        book.setCoverFileName(null);
+        book.setStatus(BookStatus.WANT_TO_READ);
+        book.setCreatedAt(Instant.now());
+        book.setGenres(Collections.emptySet());
+
+        ReadingAttemptEntity entity = new ReadingAttemptEntity();
+        entity.setId(id);
+        entity.setBook(book);
+        entity.setStatus(status);
+        entity.setStartedAt(startedAt);
+        entity.setFinishedAt(finishedAt);
+
+        ReadingAttempt result = readingAttemptDataMapper.toDomain(entity);
+
+        assertEquals(id, result.id());
+        assertEquals(bookId, result.bookId());
+        assertEquals(status, result.status());
+        assertEquals(startedAt, result.startedAt());
+        assertEquals(finishedAt, result.finishedAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingSessionDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingSessionDataMapperTest.java
@@ -1,0 +1,57 @@
+package ru.jerael.booktracker.backend.data.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingSessionEntity;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
+import java.time.Instant;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReadingSessionDataMapperTest {
+    private final ReadingSessionDataMapper readingSessionDataMapper = new ReadingSessionDataMapper();
+
+    private final UUID id = UUID.fromString("4f38de27-b492-4b27-96ea-32331bc82598");
+    private final UUID attemptId = UUID.fromString("baf246c3-5f17-495f-a8be-f724dcc8d485");
+    private final int startPage = 10;
+    private final int endPage = 25;
+    private final Instant startedAt = Instant.now().minusSeconds(1000);
+    private final Instant finishedAt = Instant.now();
+
+    @Test
+    void toEntity() {
+        ReadingSession readingSession = new ReadingSession(id, attemptId, startPage, endPage, startedAt, finishedAt);
+
+        ReadingSessionEntity entity = readingSessionDataMapper.toEntity(readingSession);
+
+        assertEquals(id, entity.getId());
+        assertEquals(attemptId, entity.getReadingAttempt().getId());
+        assertEquals(startPage, entity.getStartPage());
+        assertEquals(endPage, entity.getEndPage());
+        assertEquals(startedAt, entity.getStartedAt());
+        assertEquals(finishedAt, entity.getFinishedAt());
+    }
+
+    @Test
+    void toDomain() {
+        ReadingAttemptEntity attemptEntity = new ReadingAttemptEntity();
+        attemptEntity.setId(attemptId);
+
+        ReadingSessionEntity readingSession = new ReadingSessionEntity();
+        readingSession.setId(id);
+        readingSession.setReadingAttempt(attemptEntity);
+        readingSession.setStartPage(startPage);
+        readingSession.setEndPage(endPage);
+        readingSession.setStartedAt(startedAt);
+        readingSession.setFinishedAt(finishedAt);
+
+        ReadingSession result = readingSessionDataMapper.toDomain(readingSession);
+
+        assertEquals(id, result.id());
+        assertEquals(attemptId, result.attemptId());
+        assertEquals(startPage, result.startPage());
+        assertEquals(endPage, result.endPage());
+        assertEquals(startedAt, result.startedAt());
+        assertEquals(finishedAt, result.finishedAt());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImplTest.java
@@ -1,0 +1,64 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
+import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaAuthorRepository;
+import ru.jerael.booktracker.backend.data.mapper.AuthorDataMapper;
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({AuthorRepositoryImpl.class, AuthorDataMapper.class})
+class AuthorRepositoryImplTest {
+
+    @Autowired
+    private AuthorRepositoryImpl authorRepository;
+
+    @Autowired
+    private JpaAuthorRepository jpaAuthorRepository;
+
+    private final String fullName = "Full Name";
+
+    @Test
+    void findByFullName_WhenExists_ShouldReturnAuthor() {
+        AuthorEntity entity = new AuthorEntity();
+        entity.setFullName(fullName);
+        AuthorEntity savedEntity = jpaAuthorRepository.save(entity);
+
+        Optional<Author> result = authorRepository.findByFullName("full name");
+
+        assertTrue(result.isPresent());
+        assertEquals(savedEntity.getId(), result.get().id());
+        assertEquals(fullName, result.get().fullName());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewAuthor() {
+        Author author = new Author(null, fullName);
+
+        Author result = authorRepository.save(author);
+
+        assertNotNull(result.id());
+        assertEquals(fullName, result.fullName());
+    }
+
+    @Test
+    void save_WhenIdIsPresent_ShouldUpdateExistingAuthor() {
+        Author author = new Author(null, fullName);
+
+        UUID savedId = authorRepository.save(author).id();
+
+        Author newAuthor = new Author(savedId, "New Name");
+
+        Author result = authorRepository.save(newAuthor);
+
+        assertEquals(savedId, result.id());
+        assertEquals("New Name", result.fullName());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImplTest.java
@@ -1,0 +1,57 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.LanguageEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaLanguageRepository;
+import ru.jerael.booktracker.backend.data.mapper.LanguageDataMapper;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import java.util.List;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@Import({LanguageRepositoryImpl.class, LanguageDataMapper.class})
+class LanguageRepositoryImplTest {
+
+    @Autowired
+    private LanguageRepositoryImpl languageRepository;
+
+    @Autowired
+    private JpaLanguageRepository jpaLanguageRepository;
+
+    @Test
+    void findAll_ShouldReturnListOfLanguages() {
+        LanguageEntity entity1 = new LanguageEntity();
+        entity1.setCode("en");
+        entity1.setName("English");
+        LanguageEntity entity2 = new LanguageEntity();
+        entity2.setCode("ru");
+        entity2.setName("Русский");
+        jpaLanguageRepository.save(entity1);
+        jpaLanguageRepository.save(entity2);
+
+        List<Language> languages = languageRepository.findAll();
+
+        assertEquals(2, languages.size());
+        assertEquals("en", languages.get(0).code());
+        assertEquals("ru", languages.get(1).code());
+    }
+
+    @Test
+    void findByCode_WhenExists_ShouldReturnLanguage() {
+        LanguageEntity entity1 = new LanguageEntity();
+        entity1.setCode("en");
+        entity1.setName("English");
+        jpaLanguageRepository.save(entity1);
+
+        Optional<Language> language = languageRepository.findByCode("en");
+
+        assertTrue(language.isPresent());
+        assertEquals("en", language.get().code());
+        assertEquals("English", language.get().name());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImplTest.java
@@ -1,0 +1,144 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaNoteRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
+import ru.jerael.booktracker.backend.data.mapper.NoteDataMapper;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+import ru.jerael.booktracker.backend.domain.model.note.NoteType;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@Import({NoteRepositoryImpl.class, NoteDataMapper.class})
+class NoteRepositoryImplTest {
+
+    @Autowired
+    private NoteRepositoryImpl noteRepository;
+
+    @Autowired
+    private JpaNoteRepository jpaNoteRepository;
+
+    @Autowired
+    private JpaBookRepository jpaBookRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    private final NoteType type = NoteType.TEXT;
+    private final String textContent = "text content";
+    private final String fileName = "file_name.txt";
+    private final int pageNumber = 123;
+    private final Instant createdAt = Instant.ofEpochMilli(1773826150059L);
+
+    @Test
+    void findAllByBookId_ShouldReturnListOfNotesForBookWithBookId() {
+        UUID userId = saveUser();
+        BookEntity book1 = saveBook(userId);
+        BookEntity book2 = saveBook(userId);
+
+        NoteEntity entity1 = buildNoteEntity(book1, type);
+        jpaNoteRepository.save(entity1);
+
+        NoteEntity entity2 = buildNoteEntity(book1, NoteType.IMAGE);
+        jpaNoteRepository.save(entity2);
+
+        NoteEntity entity3 = buildNoteEntity(book2, NoteType.AUDIO);
+        jpaNoteRepository.save(entity3);
+
+        List<Note> notes = noteRepository.findAllByBookId(book1.getId());
+
+        assertEquals(2, notes.size());
+        assertEquals(NoteType.TEXT, notes.get(0).type());
+        assertEquals(NoteType.IMAGE, notes.get(1).type());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewNote() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        Note note = buildNote(null, book.getId(), type);
+
+        Note result = noteRepository.save(note);
+
+        assertNotNull(result.id());
+        assertEquals(book.getId(), result.bookId());
+        assertEquals(type, result.type());
+        assertEquals(textContent, result.textContent());
+        assertEquals(fileName, result.fileName());
+        assertEquals(pageNumber, result.pageNumber());
+        assertEquals(createdAt, result.createdAt());
+    }
+
+    @Test
+    void save_WhenIdIsPresent_ShouldUpdateExistingNote() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        Note note = buildNote(null, book.getId(), type);
+
+        UUID noteId = noteRepository.save(note).id();
+
+        Note newNote = buildNote(noteId, book.getId(), NoteType.VIDEO);
+
+        Note result = noteRepository.save(newNote);
+
+        assertEquals(noteId, result.id());
+        assertEquals(NoteType.VIDEO, result.type());
+    }
+
+    private BookEntity saveBook(UUID userId) {
+        BookEntity entity = new BookEntity();
+        entity.setUserId(userId);
+        entity.setTitle("title");
+        entity.setAuthor("author");
+        entity.setCoverFileName(null);
+        entity.setStatus(BookStatus.WANT_TO_READ);
+        entity.setCreatedAt(Instant.now());
+        entity.setGenres(Collections.emptySet());
+        return jpaBookRepository.save(entity);
+    }
+
+    private UUID saveUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail("test@example.com");
+        entity.setPasswordHash("password hash");
+        entity.setVerified(true);
+        entity.setCreatedAt(Instant.now());
+        return jpaUserRepository.save(entity).getId();
+    }
+
+    private NoteEntity buildNoteEntity(BookEntity book, NoteType type) {
+        NoteEntity entity = new NoteEntity();
+        entity.setBook(book);
+        entity.setType(type);
+        entity.setTextContent(textContent);
+        entity.setFileName(fileName);
+        entity.setPageNumber(pageNumber);
+        entity.setCreatedAt(createdAt);
+        return entity;
+    }
+
+    private Note buildNote(UUID id, UUID bookId, NoteType type) {
+        return new Note(
+            id,
+            bookId,
+            type,
+            textContent,
+            fileName,
+            pageNumber,
+            createdAt
+        );
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImplTest.java
@@ -1,0 +1,63 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaPublisherRepository;
+import ru.jerael.booktracker.backend.data.mapper.PublisherDataMapper;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({PublisherRepositoryImpl.class, PublisherDataMapper.class})
+class PublisherRepositoryImplTest {
+
+    @Autowired
+    private PublisherRepositoryImpl publisherRepository;
+
+    @Autowired
+    private JpaPublisherRepository jpaPublisherRepository;
+
+    private final String name = "Publisher Name";
+
+    @Test
+    void findByName_WhenExists_ShouldReturnPublisher() {
+        PublisherEntity entity = new PublisherEntity();
+        entity.setName(name);
+        PublisherEntity savedEntity = jpaPublisherRepository.save(entity);
+
+        Optional<Publisher> result = publisherRepository.findByName("publisher name");
+
+        assertTrue(result.isPresent());
+        assertEquals(savedEntity.getId(), result.get().id());
+        assertEquals(name, result.get().name());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewPublisher() {
+        Publisher publisher = new Publisher(null, name);
+
+        Publisher result = publisherRepository.save(publisher);
+
+        assertNotNull(result);
+        assertEquals(name, result.name());
+    }
+
+    @Test
+    void save_WhenIdIsPresent_ShouldUpdateExistingPublisher() {
+        Publisher publisher = new Publisher(null, name);
+
+        UUID savedId = publisherRepository.save(publisher).id();
+
+        Publisher newPublisher = new Publisher(savedId, "New Publisher");
+
+        Publisher result = publisherRepository.save(newPublisher);
+
+        assertEquals(savedId, result.id());
+        assertEquals("New Publisher", result.name());
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
@@ -1,0 +1,153 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaReadingAttemptRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
+import ru.jerael.booktracker.backend.data.mapper.ReadingAttemptDataMapper;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@Import({ReadingAttemptRepositoryImpl.class, ReadingAttemptDataMapper.class})
+class ReadingAttemptRepositoryImplTest {
+
+    @Autowired
+    private ReadingAttemptRepositoryImpl readingAttemptRepository;
+
+    @Autowired
+    private JpaReadingAttemptRepository jpaReadingAttemptRepository;
+
+    @Autowired
+    private JpaBookRepository jpaBookRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    private final UUID userId = UUID.fromString("57702775-4f01-4849-97e5-8c7456e01b5b");
+    private final UUID id = UUID.fromString("4f38de27-b492-4b27-96ea-32331bc82598");
+    private final UUID bookId = UUID.fromString("baf246c3-5f17-495f-a8be-f724dcc8d485");
+    private final BookStatus status = BookStatus.READING;
+    private final Instant startedAt = Instant.now().minusSeconds(1000);
+    private final Instant finishedAt = Instant.now();
+
+    @Test
+    void findAllByBookId_ShouldReturnListOfReadingAttemptsOfBook() {
+        UUID userId = saveUser();
+        BookEntity book1 = saveBook(userId);
+        BookEntity book2 = saveBook(userId);
+
+        ReadingAttemptEntity entity1 = buildReadingAttemptEntity(book1, BookStatus.READING);
+        jpaReadingAttemptRepository.save(entity1);
+
+        ReadingAttemptEntity entity2 = buildReadingAttemptEntity(book1, BookStatus.READ);
+        jpaReadingAttemptRepository.save(entity2);
+
+        ReadingAttemptEntity entity3 = buildReadingAttemptEntity(book2, BookStatus.WANT_TO_READ);
+        jpaReadingAttemptRepository.save(entity3);
+
+        List<ReadingAttempt> attempts = readingAttemptRepository.findAllByBookId(book1.getId());
+
+        assertEquals(2, attempts.size());
+    }
+
+    @Test
+    void findAllByBookIdAndStatus_ShouldReturnListOfReadingAttemptsOfBookWithStatus() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+
+        ReadingAttemptEntity entity1 = buildReadingAttemptEntity(book, BookStatus.READING);
+        jpaReadingAttemptRepository.save(entity1);
+
+        ReadingAttemptEntity entity2 = buildReadingAttemptEntity(book, BookStatus.READ);
+        jpaReadingAttemptRepository.save(entity2);
+
+        List<ReadingAttempt> attempts =
+            readingAttemptRepository.findAllByBookIdAndStatus(book.getId(), BookStatus.READING);
+
+        assertEquals(1, attempts.size());
+        assertEquals(BookStatus.READING, attempts.get(0).status());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewReadingAttempt() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        ReadingAttempt attempt = buildReadingAttempt(null, book.getId(), status);
+
+        ReadingAttempt result = readingAttemptRepository.save(attempt);
+
+        assertNotNull(result.id());
+        assertEquals(book.getId(), result.bookId());
+        assertEquals(status, result.status());
+        assertNotNull(result.startedAt());
+    }
+
+    @Test
+    void save_WhenIdIsPresent_ShouldUpdateExistingReadingAttempt() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        ReadingAttempt attempt = buildReadingAttempt(null, book.getId(), status);
+
+        UUID savedId = readingAttemptRepository.save(attempt).id();
+
+        ReadingAttempt updatedAttempt = buildReadingAttempt(savedId, book.getId(), BookStatus.WANT_TO_READ);
+
+        ReadingAttempt result = readingAttemptRepository.save(updatedAttempt);
+
+        assertEquals(savedId, result.id());
+        assertEquals(BookStatus.WANT_TO_READ, result.status());
+    }
+
+    private BookEntity saveBook(UUID userId) {
+        BookEntity entity = new BookEntity();
+        entity.setUserId(userId);
+        entity.setTitle("title");
+        entity.setAuthor("author");
+        entity.setCoverFileName(null);
+        entity.setStatus(BookStatus.WANT_TO_READ);
+        entity.setCreatedAt(Instant.now());
+        entity.setGenres(Collections.emptySet());
+        return jpaBookRepository.save(entity);
+    }
+
+    private UUID saveUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail("test@example.com");
+        entity.setPasswordHash("password hash");
+        entity.setVerified(true);
+        entity.setCreatedAt(Instant.now());
+        return jpaUserRepository.save(entity).getId();
+    }
+
+    private ReadingAttemptEntity buildReadingAttemptEntity(BookEntity book, BookStatus status) {
+        ReadingAttemptEntity entity = new ReadingAttemptEntity();
+        entity.setBook(book);
+        entity.setStatus(status);
+        entity.setStartedAt(startedAt);
+        entity.setFinishedAt(finishedAt);
+        return entity;
+    }
+
+    private ReadingAttempt buildReadingAttempt(UUID id, UUID bookId, BookStatus status) {
+        return new ReadingAttempt(
+            id,
+            bookId,
+            status,
+            startedAt,
+            finishedAt
+        );
+    }
+}

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
@@ -11,8 +11,10 @@ import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaReadingAttemptRepository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
 import ru.jerael.booktracker.backend.data.mapper.ReadingAttemptDataMapper;
+import ru.jerael.booktracker.backend.data.mapper.ReadingSessionDataMapper;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -21,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DataJpaTest
-@Import({ReadingAttemptRepositoryImpl.class, ReadingAttemptDataMapper.class})
+@Import({ReadingAttemptRepositoryImpl.class, ReadingAttemptDataMapper.class, ReadingSessionDataMapper.class})
 class ReadingAttemptRepositoryImplTest {
 
     @Autowired
@@ -36,12 +38,13 @@ class ReadingAttemptRepositoryImplTest {
     @Autowired
     private JpaUserRepository jpaUserRepository;
 
-    private final UUID userId = UUID.fromString("57702775-4f01-4849-97e5-8c7456e01b5b");
-    private final UUID id = UUID.fromString("4f38de27-b492-4b27-96ea-32331bc82598");
-    private final UUID bookId = UUID.fromString("baf246c3-5f17-495f-a8be-f724dcc8d485");
     private final BookStatus status = BookStatus.READING;
     private final Instant startedAt = Instant.now().minusSeconds(1000);
     private final Instant finishedAt = Instant.now();
+    private final List<ReadingSession> sessions = List.of(
+        new ReadingSession(null, null, 5, 10, startedAt, finishedAt),
+        new ReadingSession(null, null, 15, 20, startedAt, finishedAt)
+    );
 
     @Test
     void findAllByBookId_ShouldReturnListOfReadingAttemptsOfBook() {
@@ -93,6 +96,8 @@ class ReadingAttemptRepositoryImplTest {
         assertEquals(book.getId(), result.bookId());
         assertEquals(status, result.status());
         assertNotNull(result.startedAt());
+        assertEquals(2, result.sessions().size());
+        assertNotNull(result.sessions().get(0).id());
     }
 
     @Test
@@ -147,7 +152,8 @@ class ReadingAttemptRepositoryImplTest {
             bookId,
             status,
             startedAt,
-            finishedAt
+            finishedAt,
+            sessions
         );
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImplTest.java
@@ -1,0 +1,155 @@
+package ru.jerael.booktracker.backend.data.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.entity.ReadingSessionEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
+import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaReadingAttemptRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaReadingSessionRepository;
+import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
+import ru.jerael.booktracker.backend.data.mapper.ReadingSessionDataMapper;
+import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@Import({ReadingSessionRepositoryImpl.class, ReadingSessionDataMapper.class})
+class ReadingSessionRepositoryImplTest {
+
+    @Autowired
+    private ReadingSessionRepositoryImpl readingSessionRepository;
+
+    @Autowired
+    private JpaReadingSessionRepository jpaReadingSessionRepository;
+
+    @Autowired
+    private JpaReadingAttemptRepository jpaReadingAttemptRepository;
+
+    @Autowired
+    private JpaBookRepository jpaBookRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    private final int startPage = 10;
+    private final int endPage = 25;
+    private final Instant startedAt = Instant.now().minusSeconds(1000);
+    private final Instant finishedAt = Instant.now();
+    private final BookStatus status = BookStatus.READING;
+
+    @Test
+    void findAllByAttemptId_ShouldReturnListOfSessionsInAttempt() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        ReadingAttemptEntity readingAttempt = saveReadingAttempt(book, status);
+
+        ReadingSessionEntity entity1 = buildReadingSessionEntity(readingAttempt, 0, 10);
+        jpaReadingSessionRepository.save(entity1);
+
+        ReadingSessionEntity entity2 = buildReadingSessionEntity(readingAttempt, 10, 25);
+        jpaReadingSessionRepository.save(entity2);
+
+        List<ReadingSession> result = readingSessionRepository.findAllByAttemptId(readingAttempt.getId());
+
+        assertEquals(2, result.size());
+        assertEquals(0, result.get(0).startPage());
+        assertEquals(10, result.get(0).endPage());
+    }
+
+    @Test
+    void save_WhenIdIsNull_ShouldInsertNewReadingSession() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        ReadingAttemptEntity readingAttempt = saveReadingAttempt(book, status);
+        ReadingSession readingSession = buildReadingSession(null, readingAttempt.getId(), startPage, endPage);
+
+        ReadingSession result = readingSessionRepository.save(readingSession);
+
+        assertNotNull(result.id());
+        assertEquals(readingAttempt.getId(), result.attemptId());
+        assertEquals(startPage, result.startPage());
+    }
+
+    @Test
+    void save_WhenIdIsPresent_ShouldUpdateExistingReadingSession() {
+        UUID userId = saveUser();
+        BookEntity book = saveBook(userId);
+        ReadingAttemptEntity readingAttempt = saveReadingAttempt(book, status);
+        ReadingSession readingSession = buildReadingSession(null, readingAttempt.getId(), startPage, endPage);
+
+        UUID savedId = readingSessionRepository.save(readingSession).id();
+
+        ReadingSession updatedReadingSession = buildReadingSession(savedId, readingAttempt.getId(), 50, 100);
+
+        ReadingSession result = readingSessionRepository.save(updatedReadingSession);
+
+        assertEquals(savedId, result.id());
+        assertEquals(readingAttempt.getId(), result.attemptId());
+        assertEquals(50, result.startPage());
+    }
+
+    private BookEntity saveBook(UUID userId) {
+        BookEntity entity = new BookEntity();
+        entity.setUserId(userId);
+        entity.setTitle("title");
+        entity.setAuthor("author");
+        entity.setCoverFileName(null);
+        entity.setStatus(BookStatus.WANT_TO_READ);
+        entity.setCreatedAt(Instant.now());
+        entity.setGenres(Collections.emptySet());
+        return jpaBookRepository.save(entity);
+    }
+
+    private UUID saveUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail("test@example.com");
+        entity.setPasswordHash("password hash");
+        entity.setVerified(true);
+        entity.setCreatedAt(Instant.now());
+        return jpaUserRepository.save(entity).getId();
+    }
+
+    private ReadingAttemptEntity saveReadingAttempt(BookEntity book, BookStatus status) {
+        ReadingAttemptEntity entity = new ReadingAttemptEntity();
+        entity.setBook(book);
+        entity.setStatus(status);
+        entity.setStartedAt(startedAt);
+        entity.setFinishedAt(finishedAt);
+        return jpaReadingAttemptRepository.save(entity);
+    }
+
+    private ReadingSessionEntity buildReadingSessionEntity(
+        ReadingAttemptEntity attemptEntity,
+        int startPage,
+        int endPage
+    ) {
+        ReadingSessionEntity entity = new ReadingSessionEntity();
+        entity.setReadingAttempt(attemptEntity);
+        entity.setStartPage(startPage);
+        entity.setEndPage(endPage);
+        entity.setStartedAt(startedAt);
+        entity.setFinishedAt(finishedAt);
+        return entity;
+    }
+
+    private ReadingSession buildReadingSession(UUID id, UUID attemptId, int startPage, int endPage) {
+        return new ReadingSession(
+            id,
+            attemptId,
+            startPage,
+            endPage,
+            startedAt,
+            finishedAt
+        );
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Added domain models: `Author`, `Publisher`, `Language`, `Note`, `ReadingAttempt` and `ReadingSession`.
- Added entities: `AuthorEntity`, `PublisherEntity`, `LanguageEntity`, `NoteEntity`, `ReadingAttemptEntity` and `ReadingSessionEntity`.
- Implemented mappers in data layer: `AuthorDataMapper`, `PublisherDataMapper`, `LanguageDataMapper`, `NoteDataMapper`, `ReadingAttemptDataMapper` and `ReadingSessionDataMapper`.
- Implemented repositories: `AuthorRepository`, `PublisherRepository`, `LanguageRepository`, `NoteRepository`, `ReadingAttemptRepository` and `ReadingSessionRepository`.

Tests:
- Added tests for new mappers and repositories.

### Related tickets

Part of #113

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
