### PR TITLE
feat: expand book entity

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -12,6 +12,7 @@ import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
 import ru.jerael.booktracker.backend.domain.usecase.book.CreateBookUseCase;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -33,6 +34,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
                 .collect(Collectors.toSet());
             throw GenreExceptionFactory.genresNotFound(missingIds);
         }
+        // TODO: provide real data when BookCreation will be updated
         Book newBook = new Book(
             null,
             data.title(),
@@ -40,7 +42,17 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
             null,
             data.status() != null ? data.status() : BookStatus.WANT_TO_READ,
             Instant.now(),
-            genres
+            genres,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
         );
         return bookRepository.save(newBook, userId);
     }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
@@ -30,7 +30,17 @@ public class DeleteCoverUseCaseImpl implements DeleteCoverUseCase {
             null,
             book.status(),
             book.createdAt(),
-            book.genres()
+            book.genres(),
+            book.authors(),
+            book.description(),
+            book.publisher(),
+            book.language(),
+            book.publishedOn(),
+            book.totalPages(),
+            book.isbn10(),
+            book.isbn13(),
+            book.attempts(),
+            book.notes()
         );
         bookRepository.save(updatedBook, userId);
         bookCoverStorage.delete(book.coverFileName());

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
@@ -39,6 +39,7 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
             }
         }
 
+        // TODO: provide real data when BookDetailsUpdate will be updated
         Book updatedBook = new Book(
             book.id(),
             data.title() != null ? data.title().trim() : book.title(),
@@ -46,7 +47,17 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
             book.coverFileName(),
             data.status() != null ? data.status() : book.status(),
             book.createdAt(),
-            updatedGenres
+            updatedGenres,
+            book.authors(),
+            book.description(),
+            book.publisher(),
+            book.language(),
+            book.publishedOn(),
+            book.totalPages(),
+            book.isbn10(),
+            book.isbn13(),
+            book.attempts(),
+            book.notes()
         );
         return bookRepository.save(updatedBook, userId);
     }

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
@@ -58,7 +58,17 @@ public class UploadCoverUseCaseImpl implements UploadCoverUseCase {
             newCoverFileName,
             book.status(),
             book.createdAt(),
-            book.genres()
+            book.genres(),
+            book.authors(),
+            book.description(),
+            book.publisher(),
+            book.language(),
+            book.publishedOn(),
+            book.totalPages(),
+            book.isbn10(),
+            book.isbn13(),
+            book.attempts(),
+            book.notes()
         );
         Book savedBook = bookRepository.save(updatedBook, userId);
         if (oldCoverFileName != null && !oldCoverFileName.equals(newCoverFileName)) {

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/constant/Tables.java
@@ -16,4 +16,5 @@ public class Tables {
     public final String NOTES = "notes";
     public final String READING_ATTEMPTS = "reading_attempts";
     public final String READING_SESSIONS = "reading_sessions";
+    public final String BOOK_AUTHORS = "book_authors";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
@@ -8,9 +8,8 @@ import ru.jerael.booktracker.backend.data.db.constant.Tables;
 import ru.jerael.booktracker.backend.domain.constant.BookRules;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import java.time.Instant;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import java.time.LocalDate;
+import java.util.*;
 
 @Entity
 @Table(name = Tables.BOOKS)
@@ -49,4 +48,51 @@ public class BookEntity {
         inverseJoinColumns = @JoinColumn(name = "genre_id")
     )
     private Set<GenreEntity> genres = new HashSet<>();
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = Tables.BOOK_AUTHORS,
+        joinColumns = @JoinColumn(name = "book_id"),
+        inverseJoinColumns = @JoinColumn(name = "author_id")
+    )
+    private Set<AuthorEntity> authors = new HashSet<>();
+
+    @Column(name = "description", length = BookRules.DESCRIPTION_MAX_LENGTH)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id")
+    private PublisherEntity publisher;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "language_code")
+    private LanguageEntity language;
+
+    @Column(name = "published_on")
+    private LocalDate publishedOn;
+
+    @Column(name = "total_pages")
+    private int totalPages;
+
+    @Column(name = "isbn_10", length = 10)
+    private String isbn10;
+
+    @Column(name = "isbn_13", length = 13)
+    private String isbn13;
+
+    @OneToMany(
+        mappedBy = "book",
+        fetch = FetchType.LAZY,
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private List<ReadingAttemptEntity> attempts = new ArrayList<>();
+
+    @OneToMany(
+        mappedBy = "book",
+        fetch = FetchType.LAZY,
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private List<NoteEntity> notes = new ArrayList<>();
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
@@ -72,7 +72,7 @@ public class BookEntity {
     private LocalDate publishedOn;
 
     @Column(name = "total_pages")
-    private int totalPages;
+    private Integer totalPages;
 
     @Column(name = "isbn_10", length = 10)
     private String isbn10;

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaBookRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaBookRepository.java
@@ -2,6 +2,7 @@ package ru.jerael.booktracker.backend.data.db.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
@@ -10,8 +11,10 @@ import java.util.UUID;
 
 @Repository
 public interface JpaBookRepository extends JpaRepository<BookEntity, UUID> {
+    @EntityGraph(attributePaths = {"publisher", "language"})
     Page<BookEntity> findAllByUserId(Pageable pageable, UUID userId);
 
+    @EntityGraph(attributePaths = {"publisher", "language"})
     Optional<BookEntity> findByIdAndUserId(UUID id, UUID userId);
 
     void deleteByIdAndUserId(UUID id, UUID userId);

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapper.java
@@ -1,21 +1,25 @@
 package ru.jerael.booktracker.backend.data.mapper;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
+@RequiredArgsConstructor
 public class BookDataMapper {
     private final GenreDataMapper genreDataMapper;
-
-    public BookDataMapper(GenreDataMapper genreDataMapper) {
-        this.genreDataMapper = genreDataMapper;
-    }
+    private final AuthorDataMapper authorDataMapper;
+    private final PublisherDataMapper publisherDataMapper;
+    private final LanguageDataMapper languageDataMapper;
+    private final ReadingAttemptDataMapper readingAttemptDataMapper;
+    private final NoteDataMapper noteDataMapper;
 
     public Book toDomain(BookEntity entity) {
         if (entity == null) return null;
@@ -28,7 +32,20 @@ public class BookDataMapper {
             entity.getStatus(),
             entity.getCreatedAt(),
             entity.getGenres() == null ? Collections.emptySet() :
-                entity.getGenres().stream().map(genreDataMapper::toDomain).collect(Collectors.toSet())
+                entity.getGenres().stream().map(genreDataMapper::toDomain).collect(Collectors.toSet()),
+            entity.getAuthors() == null ? Collections.emptySet() :
+                entity.getAuthors().stream().map(authorDataMapper::toDomain).collect(Collectors.toSet()),
+            entity.getDescription(),
+            publisherDataMapper.toDomain(entity.getPublisher()),
+            languageDataMapper.toDomain(entity.getLanguage()),
+            entity.getPublishedOn(),
+            entity.getTotalPages(),
+            entity.getIsbn10(),
+            entity.getIsbn13(),
+            entity.getAttempts() == null ? List.of() :
+                entity.getAttempts().stream().map(readingAttemptDataMapper::toDomain).toList(),
+            entity.getNotes() == null ? List.of() :
+                entity.getNotes().stream().map(noteDataMapper::toDomain).toList()
         );
     }
 
@@ -44,6 +61,19 @@ public class BookDataMapper {
         entity.setCreatedAt(book.createdAt());
         entity.setGenres(book.genres() == null ? Collections.emptySet() :
             book.genres().stream().map(genreDataMapper::toEntity).collect(Collectors.toSet()));
+        entity.setAuthors(book.authors() == null ? Collections.emptySet() :
+            book.authors().stream().map(authorDataMapper::toEntity).collect(Collectors.toSet()));
+        entity.setDescription(book.description());
+        entity.setPublisher(publisherDataMapper.toEntity(book.publisher()));
+        entity.setLanguage(languageDataMapper.toEntity(book.language()));
+        entity.setPublishedOn(book.publishedOn());
+        entity.setTotalPages(book.totalPages());
+        entity.setIsbn10(book.isbn10());
+        entity.setIsbn13(book.isbn13());
+        entity.setAttempts(book.attempts() == null ? List.of() :
+            book.attempts().stream().map(readingAttemptDataMapper::toEntity).toList());
+        entity.setNotes(book.notes() == null ? List.of() :
+            book.notes().stream().map(noteDataMapper::toEntity).toList());
         return entity;
     }
 

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/LanguageDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/LanguageDataMapper.java
@@ -6,6 +6,15 @@ import ru.jerael.booktracker.backend.domain.model.language.Language;
 
 @Component
 public class LanguageDataMapper {
+    public LanguageEntity toEntity(Language language) {
+        if (language == null) return null;
+
+        LanguageEntity entity = new LanguageEntity();
+        entity.setCode(language.code());
+        entity.setName(language.name());
+        return entity;
+    }
+
     public Language toDomain(LanguageEntity entity) {
         if (entity == null) return null;
 

--- a/src/main/java/ru/jerael/booktracker/backend/domain/constant/BookRules.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/constant/BookRules.java
@@ -5,5 +5,6 @@ public final class BookRules {
 
     public static final int TITLE_MAX_LENGTH = 500;
     public static final int AUTHOR_MAX_LENGTH = 500;
+    public static final int DESCRIPTION_MAX_LENGTH = 5000;
     public static final String COVER_FIELD_NAME = "cover";
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/Book.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/Book.java
@@ -2,7 +2,14 @@ package ru.jerael.booktracker.backend.domain.model.book;
 
 import jakarta.annotation.Nullable;
 import ru.jerael.booktracker.backend.domain.model.Genre;
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -13,5 +20,15 @@ public record Book(
     @Nullable String coverFileName,
     BookStatus status,
     Instant createdAt,
-    Set<Genre> genres
+    Set<Genre> genres,
+    Set<Author> authors,
+    @Nullable String description,
+    @Nullable Publisher publisher,
+    @Nullable Language language,
+    @Nullable LocalDate publishedOn,
+    @Nullable Integer totalPages,
+    @Nullable String isbn10,
+    @Nullable String isbn13,
+    List<ReadingAttempt> attempts,
+    List<Note> notes
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/author/AuthorResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/author/AuthorResponse.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.web.dto.author;
+
+import java.util.UUID;
+
+public record AuthorResponse(
+    UUID id,
+    String fullName
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/book/BookResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/book/BookResponse.java
@@ -2,8 +2,15 @@ package ru.jerael.booktracker.backend.web.dto.book;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
+import ru.jerael.booktracker.backend.web.dto.author.AuthorResponse;
 import ru.jerael.booktracker.backend.web.dto.genre.GenreResponse;
+import ru.jerael.booktracker.backend.web.dto.language.LanguageResponse;
+import ru.jerael.booktracker.backend.web.dto.note.NoteResponse;
+import ru.jerael.booktracker.backend.web.dto.publisher.PublisherResponse;
+import ru.jerael.booktracker.backend.web.dto.reading_attempt.ReadingAttemptResponse;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -20,5 +27,22 @@ public record BookResponse(
     Instant createdAt,
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    Set<GenreResponse> genres
+    Set<GenreResponse> genres,
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    Set<AuthorResponse> authors,
+
+    String description,
+    PublisherResponse publisher,
+    LanguageResponse language,
+    LocalDate publishedOn,
+    Integer totalPages,
+    String isbn10,
+    String isbn13,
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    List<ReadingAttemptResponse> attempts,
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    List<NoteResponse> notes
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/language/LanguageResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/language/LanguageResponse.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.web.dto.language;
+
+public record LanguageResponse(
+    String code,
+    String name
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/note/NoteResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/note/NoteResponse.java
@@ -1,0 +1,14 @@
+package ru.jerael.booktracker.backend.web.dto.note;
+
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NoteResponse(
+    UUID id,
+    String type,
+    @Nullable String textContent,
+    @Nullable String fileName,
+    int pageNumber,
+    Instant createdAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/publisher/PublisherResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/publisher/PublisherResponse.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.web.dto.publisher;
+
+import java.util.UUID;
+
+public record PublisherResponse(
+    UUID id,
+    String name
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/reading_attempt/ReadingAttemptResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/reading_attempt/ReadingAttemptResponse.java
@@ -1,0 +1,15 @@
+package ru.jerael.booktracker.backend.web.dto.reading_attempt;
+
+import jakarta.annotation.Nullable;
+import ru.jerael.booktracker.backend.web.dto.reading_session.ReadingSessionResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record ReadingAttemptResponse(
+    UUID id,
+    String status,
+    Instant startedAt,
+    @Nullable Instant finishedAt,
+    List<ReadingSessionResponse> sessions
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/reading_session/ReadingSessionResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/reading_session/ReadingSessionResponse.java
@@ -1,0 +1,13 @@
+package ru.jerael.booktracker.backend.web.dto.reading_session;
+
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record ReadingSessionResponse(
+    UUID id,
+    int startPage,
+    int endPage,
+    Instant startedAt,
+    @Nullable Instant finishedAt
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthorWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/AuthorWebMapper.java
@@ -1,0 +1,17 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import ru.jerael.booktracker.backend.web.dto.author.AuthorResponse;
+
+@Component
+public class AuthorWebMapper {
+    public AuthorResponse toResponse(Author author) {
+        if (author == null) return null;
+
+        return new AuthorResponse(
+            author.id(),
+            author.fullName()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapper.java
@@ -11,11 +11,17 @@ import ru.jerael.booktracker.backend.web.dto.book.BookDetailsUpdateRequest;
 import ru.jerael.booktracker.backend.web.dto.book.BookResponse;
 import ru.jerael.booktracker.backend.web.util.LinkBuilder;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class BookWebMapper {
     private final GenreWebMapper genreWebMapper;
+    private final AuthorWebMapper authorWebMapper;
+    private final PublisherWebMapper publisherWebMapper;
+    private final LanguageWebMapper languageWebMapper;
+    private final ReadingAttemptWebMapper readingAttemptWebMapper;
+    private final NoteWebMapper noteWebMapper;
     private final LinkBuilder linkBuilder;
 
     public BookResponse toResponse(Book book) {
@@ -33,7 +39,17 @@ public class BookWebMapper {
             coverUrl,
             book.status().getValue(),
             book.createdAt(),
-            genreWebMapper.toResponses(book.genres())
+            genreWebMapper.toResponses(book.genres()),
+            book.authors().stream().map(authorWebMapper::toResponse).collect(Collectors.toSet()),
+            book.description(),
+            publisherWebMapper.toResponse(book.publisher()),
+            languageWebMapper.toResponse(book.language()),
+            book.publishedOn(),
+            book.totalPages(),
+            book.isbn10(),
+            book.isbn13(),
+            book.attempts().stream().map(readingAttemptWebMapper::toResponse).toList(),
+            book.notes().stream().map(noteWebMapper::toResponse).toList()
         );
     }
 

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
@@ -1,0 +1,17 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.web.dto.language.LanguageResponse;
+
+@Component
+public class LanguageWebMapper {
+    public LanguageResponse toResponse(Language language) {
+        if (language == null) return null;
+
+        return new LanguageResponse(
+            language.code(),
+            language.name()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/NoteWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/NoteWebMapper.java
@@ -1,0 +1,21 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.note.Note;
+import ru.jerael.booktracker.backend.web.dto.note.NoteResponse;
+
+@Component
+public class NoteWebMapper {
+    public NoteResponse toResponse(Note note) {
+        if (note == null) return null;
+
+        return new NoteResponse(
+            note.id(),
+            note.type().name(),
+            note.textContent(),
+            note.fileName(),
+            note.pageNumber(),
+            note.createdAt()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/PublisherWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/PublisherWebMapper.java
@@ -1,0 +1,17 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import ru.jerael.booktracker.backend.web.dto.publisher.PublisherResponse;
+
+@Component
+public class PublisherWebMapper {
+    public PublisherResponse toResponse(Publisher publisher) {
+        if (publisher == null) return null;
+
+        return new PublisherResponse(
+            publisher.id(),
+            publisher.name()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/ReadingAttemptWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/ReadingAttemptWebMapper.java
@@ -1,0 +1,24 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
+import ru.jerael.booktracker.backend.web.dto.reading_attempt.ReadingAttemptResponse;
+
+@Component
+@RequiredArgsConstructor
+public class ReadingAttemptWebMapper {
+    private final ReadingSessionWebMapper readingSessionWebMapper;
+
+    public ReadingAttemptResponse toResponse(ReadingAttempt readingAttempt) {
+        if (readingAttempt == null) return null;
+
+        return new ReadingAttemptResponse(
+            readingAttempt.id(),
+            readingAttempt.status().getValue(),
+            readingAttempt.startedAt(),
+            readingAttempt.finishedAt(),
+            readingAttempt.sessions().stream().map(readingSessionWebMapper::toResponse).toList()
+        );
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/ReadingSessionWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/ReadingSessionWebMapper.java
@@ -1,0 +1,20 @@
+package ru.jerael.booktracker.backend.web.mapper;
+
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
+import ru.jerael.booktracker.backend.web.dto.reading_session.ReadingSessionResponse;
+
+@Component
+public class ReadingSessionWebMapper {
+    public ReadingSessionResponse toResponse(ReadingSession readingSession) {
+        if (readingSession == null) return null;
+
+        return new ReadingSessionResponse(
+            readingSession.id(),
+            readingSession.startPage(),
+            readingSession.endPage(),
+            readingSession.startedAt(),
+            readingSession.finishedAt()
+        );
+    }
+}

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -57,3 +57,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/28__add-attempts-for-books-to-reading_attempts.yaml
   - include:
       file: classpath:/db/changelog/changes/29__fill-publisher_id-and-language_code-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/30__drop-unique-constraint-for-isbn.yaml

--- a/src/main/resources/db/changelog/changes/30__drop-unique-constraint-for-isbn.yaml
+++ b/src/main/resources/db/changelog/changes/30__drop-unique-constraint-for-isbn.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 30__drop-unique-constraint-for-isbn-in-books
+      author: Jerael
+      comment: drop unique constraints for isbn in books
+      changes:
+        - dropUniqueConstraint:
+            tableName: books
+            constraintName: uq_books_isbn_10
+        - dropUniqueConstraint:
+            tableName: books
+            constraintName: uq_books_isbn_13

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
@@ -14,6 +14,7 @@ import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,7 +58,17 @@ class CreateBookUseCaseImplTest {
                 book.coverFileName(),
                 book.status(),
                 book.createdAt(),
-                book.genres()
+                book.genres(),
+                Set.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of()
             );
         });
 

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
@@ -11,9 +11,7 @@ import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.storage.BookCoverStorage;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -48,7 +46,25 @@ class DeleteBookUseCaseImplTest {
     @Test
     void execute_WhenBookHasCover_ShouldDeleteBookAndCover() {
         String coverFileName = "cover.jpg";
-        Book book = new Book(id, title, author, coverFileName, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            coverFileName,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
         useCase.execute(id, userId);
@@ -59,7 +75,25 @@ class DeleteBookUseCaseImplTest {
 
     @Test
     void execute_WhenBookHasNotCover_ShouldDeleteOnlyBook() {
-        Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
         useCase.execute(id, userId);

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
@@ -11,9 +11,7 @@ import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.storage.BookCoverStorage;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -48,19 +46,73 @@ class DeleteCoverUseCaseImplTest {
     @Test
     void execute_WhenCoverExists_ShouldDeleteFromStorageAndSaveBookWithNullCover() {
         String coverFileName = "cover.jpg";
-        Book book = new Book(id, title, author, coverFileName, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            coverFileName,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
         useCase.execute(id, userId);
 
-        Book updatedBook = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+        Book updatedBook = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         verify(bookCoverStorage).delete(coverFileName);
         verify(bookRepository).save(updatedBook, userId);
     }
 
     @Test
     void execute_WhenCoverDoesNotExists_ShouldExitWithoutUpdate() {
-        Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
         useCase.execute(id, userId);

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
@@ -11,6 +11,7 @@ import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -40,7 +41,25 @@ class GetBookByIdUseCaseImplTest {
         Genre genre1 = new Genre(1, "action");
         Genre genre2 = new Genre(2, "adventure");
         Set<Genre> genres = Set.of(genre1, genre2);
-        Book book = new Book(id, title, author, null, status, createdAt, genres);
+        Book book = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            genres,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
         Book result = useCase.execute(id, userId);

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
@@ -13,9 +13,7 @@ import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.storage.BookCoverStorage;
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
@@ -49,7 +47,25 @@ class GetBookCoverUseCaseImplTest {
             new ByteArrayInputStream(content),
             content.length
         );
-        Book book = new Book(id, title, author, coverFileName, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            coverFileName,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
         when(bookCoverStorage.download(coverFileName)).thenReturn(imageFile);
 
@@ -70,7 +86,25 @@ class GetBookCoverUseCaseImplTest {
 
     @Test
     void execute_WhenCoverDoesNotExists_ShouldThrowNotFoundException() {
-        Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.of(book));
 
         assertThrows(NotFoundException.class, () -> useCase.execute(id, userId));

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
@@ -13,10 +13,7 @@ import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,7 +40,25 @@ class UpdateBookDetailsUseCaseImplTest {
     private final String author = "author";
     private final BookStatus status = BookStatus.WANT_TO_READ;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
-    Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+    private final Book book = new Book(
+        id,
+        title,
+        author,
+        null,
+        status,
+        createdAt,
+        Collections.emptySet(),
+        Set.of(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        List.of()
+    );
 
     @Test
     void execute_WhenGenreNotFound_ShouldThrowException() {

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
@@ -18,9 +18,7 @@ import ru.jerael.booktracker.backend.domain.service.image.ImageProcessor;
 import ru.jerael.booktracker.backend.domain.storage.BookCoverStorage;
 import java.io.InputStream;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -48,7 +46,25 @@ class UploadCoverUseCaseImplTest {
     private final String author = "author";
     private final BookStatus status = BookStatus.WANT_TO_READ;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
-    private final Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+    private final Book book = new Book(
+        id,
+        title,
+        author,
+        null,
+        status,
+        createdAt,
+        Collections.emptySet(),
+        Set.of(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        List.of()
+    );
 
     @Test
     void execute_WhenBookDoesNotExists_ShouldThrowNotFoundException() {
@@ -101,7 +117,25 @@ class UploadCoverUseCaseImplTest {
     void execute_WhenOldCoverExists_ShouldDeleteOldCover() {
         String oldCoverFileName = "old_cover.jpg";
         String newCoverFileName = id + ".jpg";
-        Book book = new Book(id, title, author, oldCoverFileName, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            oldCoverFileName,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         ProcessedImage processedImage = new ProcessedImage("image/jpeg", "jpg", content, contentSize);
         UploadCover data = new UploadCover("image/jpeg", content, contentSize);
 
@@ -118,7 +152,25 @@ class UploadCoverUseCaseImplTest {
     @Test
     void execute_WhenDeleteOldCoverFails_ShouldReturnUpdatedBook() {
         String oldCoverFileName = "old_cover.jpg";
-        Book book = new Book(id, title, author, oldCoverFileName, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            oldCoverFileName,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         ProcessedImage processedImage = new ProcessedImage("image/jpeg", "jpg", content, contentSize);
         UploadCover data = new UploadCover("image/jpeg", content, contentSize);
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapperTest.java
@@ -9,6 +9,7 @@ import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -16,7 +17,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class BookDataMapperTest {
     private final GenreDataMapper genreDataMapper = new GenreDataMapper();
-    private final BookDataMapper bookDataMapper = new BookDataMapper(genreDataMapper);
+    private final AuthorDataMapper authorDataMapper = new AuthorDataMapper();
+    private final PublisherDataMapper publisherDataMapper = new PublisherDataMapper();
+    private final LanguageDataMapper languageDataMapper = new LanguageDataMapper();
+    private final ReadingSessionDataMapper readingSessionDataMapper = new ReadingSessionDataMapper();
+    private final ReadingAttemptDataMapper readingAttemptDataMapper =
+        new ReadingAttemptDataMapper(readingSessionDataMapper);
+    private final NoteDataMapper noteDataMapper = new NoteDataMapper();
+    private final BookDataMapper bookDataMapper = new BookDataMapper(
+        genreDataMapper, authorDataMapper, publisherDataMapper,
+        languageDataMapper, readingAttemptDataMapper, noteDataMapper
+    );
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final String title = "title";
@@ -27,7 +38,25 @@ class BookDataMapperTest {
     private final Genre genre1 = new Genre(1, "action");
     private final Genre genre2 = new Genre(2, "adventure");
     private final Set<Genre> genres = Set.of(genre1, genre2);
-    private final Book book = new Book(id, title, author, coverFileName, status, createdAt, genres);
+    private final Book book = new Book(
+        id,
+        title,
+        author,
+        coverFileName,
+        status,
+        createdAt,
+        genres,
+        Set.of(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        List.of()
+    );
 
     @Test
     void entity_toDomain() {

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
@@ -8,8 +8,7 @@ import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
 import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaGenreRepository;
-import ru.jerael.booktracker.backend.data.mapper.BookDataMapper;
-import ru.jerael.booktracker.backend.data.mapper.GenreDataMapper;
+import ru.jerael.booktracker.backend.data.mapper.*;
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
@@ -23,7 +22,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@Import({BookRepositoryImpl.class, GenreRepositoryImpl.class, GenreDataMapper.class, BookDataMapper.class})
+@Import({
+    BookRepositoryImpl.class,
+    GenreRepositoryImpl.class,
+    GenreDataMapper.class,
+    AuthorDataMapper.class,
+    PublisherDataMapper.class,
+    LanguageDataMapper.class,
+    ReadingSessionDataMapper.class,
+    ReadingAttemptDataMapper.class,
+    NoteDataMapper.class,
+    BookDataMapper.class
+})
 class BookRepositoryImplTest {
 
     @Autowired
@@ -122,7 +132,17 @@ class BookRepositoryImplTest {
             null,
             BookStatus.WANT_TO_READ,
             Instant.now(),
-            genres
+            genres,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
         );
 
         Book createdBook = bookRepository.save(book, userId);
@@ -146,7 +166,6 @@ class BookRepositoryImplTest {
 
         BookEntity savedBook = jpaBookRepository.save(bookEntity);
         UUID id = savedBook.getId();
-
         Book book = new Book(
             id,
             "new title",
@@ -154,7 +173,17 @@ class BookRepositoryImplTest {
             "new_cover.jpg",
             savedBook.getStatus(),
             savedBook.getCreatedAt(),
-            Collections.emptySet()
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
         );
 
         Book updatedBook = bookRepository.save(book, userId);
@@ -188,7 +217,17 @@ class BookRepositoryImplTest {
             null,
             BookStatus.WANT_TO_READ,
             Instant.now(),
-            genres
+            genres,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
         );
 
         Book createdBook = bookRepository.save(book, userId);

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -123,8 +123,26 @@ class BookControllerTest {
             List.of(),
             List.of()
         );
-        BookResponse bookResponse =
-            new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
+        BookResponse bookResponse = new BookResponse(
+            id,
+            title,
+            author,
+            null,
+            status.getValue(),
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
+
         PageResult<Book> pageResult = new PageResult<>(List.of(book), 10, 0, 1, 1);
         when(getBooksUseCase.execute(any(PageQuery.class), eq(userId))).thenReturn(pageResult);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
@@ -198,8 +216,25 @@ class BookControllerTest {
             List.of(),
             List.of()
         );
-        BookResponse bookResponse =
-            new BookResponse(id, "new title", author, null, "reading", createdAt, Collections.emptySet());
+        BookResponse bookResponse = new BookResponse(
+            id,
+            "new title",
+            author,
+            null,
+            "reading",
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookWebMapper.toDomain(request)).thenReturn(data);
         when(updateBookDetailsUseCase.execute(id, userId, data)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
@@ -243,8 +278,25 @@ class BookControllerTest {
             List.of(),
             List.of()
         );
-        BookResponse bookResponse =
-            new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
+        BookResponse bookResponse = new BookResponse(
+            id,
+            title,
+            author,
+            null,
+            status.getValue(),
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(bookWebMapper.toDomain(request)).thenReturn(data);
         when(createBookUseCase.execute(data, userId)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);
@@ -295,8 +347,25 @@ class BookControllerTest {
             List.of(),
             List.of()
         );
-        BookResponse bookResponse =
-            new BookResponse(id, title, author, coverFileName, status.getValue(), createdAt, null);
+        BookResponse bookResponse = new BookResponse(
+            id,
+            title,
+            author,
+            coverFileName,
+            status.getValue(),
+            createdAt,
+            null,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         when(uploadCoverWebMapper.toDomain(mockMultipartFile)).thenReturn(data);
         when(uploadCoverUseCase.execute(id, userId, data)).thenReturn(book);
         when(bookWebMapper.toResponse(book)).thenReturn(bookResponse);

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -104,7 +104,25 @@ class BookControllerTest {
 
     @Test
     void getAll_ShouldReturnListOfBookResponses() {
-        Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         BookResponse bookResponse =
             new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
         PageResult<Book> pageResult = new PageResult<>(List.of(book), 10, 0, 1, 1);
@@ -161,7 +179,25 @@ class BookControllerTest {
             null
         );
         BookDetailsUpdate data = new BookDetailsUpdate("new title", null, BookStatus.READING, null);
-        Book book = new Book(id, "new title", author, null, BookStatus.READING, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            "new title",
+            author,
+            null,
+            BookStatus.READING,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         BookResponse bookResponse =
             new BookResponse(id, "new title", author, null, "reading", createdAt, Collections.emptySet());
         when(bookWebMapper.toDomain(request)).thenReturn(data);
@@ -188,7 +224,25 @@ class BookControllerTest {
     void create_ShouldCreateBook() {
         BookCreationRequest request = new BookCreationRequest(title, author, status.getValue(), Set.of(1, 2));
         BookCreation data = new BookCreation(title, author, null, Set.of(1, 2));
-        Book book = new Book(id, title, author, null, status, createdAt, Collections.emptySet());
+        Book book = new Book(
+            id,
+            title,
+            author,
+            null,
+            status,
+            createdAt,
+            Collections.emptySet(),
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         BookResponse bookResponse =
             new BookResponse(id, title, author, null, status.getValue(), createdAt, Collections.emptySet());
         when(bookWebMapper.toDomain(request)).thenReturn(data);
@@ -222,7 +276,25 @@ class BookControllerTest {
             "content".getBytes()
         );
         UploadCover data = new UploadCover(MediaType.IMAGE_JPEG_VALUE, null, 0L);
-        Book book = new Book(id, title, author, coverFileName, status, createdAt, null);
+        Book book = new Book(
+            id,
+            title,
+            author,
+            coverFileName,
+            status,
+            createdAt,
+            null,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         BookResponse bookResponse =
             new BookResponse(id, title, author, coverFileName, status.getValue(), createdAt, null);
         when(uploadCoverWebMapper.toDomain(mockMultipartFile)).thenReturn(data);

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
@@ -33,7 +33,25 @@ class BookWebMapperTest {
     private final Genre genre1 = new Genre(1, "action");
     private final Genre genre2 = new Genre(2, "adventure");
     private final Set<Genre> genres = Set.of(genre1, genre2);
-    private final Book book = new Book(id, title, author, coverFileName, status, createdAt, genres);
+    private final Book book = new Book(
+        id,
+        title,
+        author,
+        coverFileName,
+        status,
+        createdAt,
+        genres,
+        Set.of(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        List.of(),
+        List.of()
+    );
 
     @Test
     void toResponse() {
@@ -54,7 +72,25 @@ class BookWebMapperTest {
     @Test
     void toResponses() {
         UUID id2 = UUID.fromString("31d3f5e3-7faf-4678-a3cf-4657d8875a82");
-        Book book2 = new Book(id2, "asd", author, coverFileName, status, createdAt, genres);
+        Book book2 = new Book(
+            id2,
+            "asd",
+            author,
+            coverFileName,
+            status,
+            createdAt,
+            genres,
+            Set.of(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            List.of()
+        );
         List<Book> books = List.of(book, book2);
         when(linkBuilder.buildCoverUrl(id)).thenReturn("url1");
         when(linkBuilder.buildCoverUrl(id2)).thenReturn("url2");

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
@@ -21,8 +21,17 @@ import static org.mockito.Mockito.when;
 
 class BookWebMapperTest {
     private final GenreWebMapper genreWebMapper = new GenreWebMapper();
+    private final AuthorWebMapper authorWebMapper = new AuthorWebMapper();
+    private final PublisherWebMapper publisherWebMapper = new PublisherWebMapper();
+    private final LanguageWebMapper languageWebMapper = new LanguageWebMapper();
+    private final ReadingSessionWebMapper readingSessionWebMapper = new ReadingSessionWebMapper();
+    private final ReadingAttemptWebMapper readingAttemptWebMapper =
+        new ReadingAttemptWebMapper(readingSessionWebMapper);
+    private final NoteWebMapper noteWebMapper = new NoteWebMapper();
     private final LinkBuilder linkBuilder = mock(LinkBuilder.class);
-    private final BookWebMapper bookWebMapper = new BookWebMapper(genreWebMapper, linkBuilder);
+    private final BookWebMapper bookWebMapper =
+        new BookWebMapper(genreWebMapper, authorWebMapper, publisherWebMapper, languageWebMapper,
+            readingAttemptWebMapper, noteWebMapper, linkBuilder);
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final String title = "title";

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -43,3 +43,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/23__set-finished_at-nullable-in-reading_attempts.yaml
   - include:
       file: classpath:/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml
+  - include:
+      file: classpath:/db/changelog/changes/30__drop-unique-constraint-for-isbn.yaml


### PR DESCRIPTION
### What does this PR do?

- Added migration for dropping unique constraints for isbn in books table.
- Added new fields to `BookEntity`.
- Expanded `Book` domain model with new fields.
- Expanded `BookResponse` dto with new fields.
- Expanded mappers (data and web layers).

Tests:
- Updated tests for using new `Book` and `BookResponse` records.

### Related tickets

Part of #113

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
