### PR TITLE
refactor: remove deprecated fields from books

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -7,7 +7,6 @@ import ru.jerael.booktracker.backend.domain.exception.factory.GenreExceptionFact
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
 import ru.jerael.booktracker.backend.domain.usecase.book.CreateBookUseCase;
@@ -38,9 +37,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
         Book newBook = new Book(
             null,
             data.title(),
-            data.author(),
             null,
-            data.status() != null ? data.status() : BookStatus.WANT_TO_READ,
             Instant.now(),
             genres,
             Set.of(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
@@ -26,9 +26,7 @@ public class DeleteCoverUseCaseImpl implements DeleteCoverUseCase {
         Book updatedBook = new Book(
             book.id(),
             book.title(),
-            book.author(),
             null,
-            book.status(),
             book.createdAt(),
             book.genres(),
             book.authors(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
@@ -43,9 +43,7 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
         Book updatedBook = new Book(
             book.id(),
             data.title() != null ? data.title().trim() : book.title(),
-            data.author() != null ? data.author().trim() : book.author(),
             book.coverFileName(),
-            data.status() != null ? data.status() : book.status(),
             book.createdAt(),
             updatedGenres,
             book.authors(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
@@ -54,9 +54,7 @@ public class UploadCoverUseCaseImpl implements UploadCoverUseCase {
         Book updatedBook = new Book(
             book.id(),
             book.title(),
-            book.author(),
             newCoverFileName,
-            book.status(),
             book.createdAt(),
             book.genres(),
             book.authors(),

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import ru.jerael.booktracker.backend.data.db.constant.Tables;
 import ru.jerael.booktracker.backend.domain.constant.BookRules;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
@@ -28,15 +27,8 @@ public class BookEntity {
     @Column(name = "title", length = BookRules.TITLE_MAX_LENGTH, nullable = false)
     private String title;
 
-    @Column(name = "author", length = BookRules.AUTHOR_MAX_LENGTH, nullable = false)
-    private String author;
-
     @Column(name = "cover_file_name")
     private String coverFileName;
-
-    @Column(name = "status", nullable = false)
-    @Enumerated(EnumType.STRING)
-    private BookStatus status = BookStatus.WANT_TO_READ;
 
     @Column(name = "created_at", updatable = false)
     private Instant createdAt;

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapper.java
@@ -3,12 +3,9 @@ package ru.jerael.booktracker.backend.data.mapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
-import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
-import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
@@ -27,9 +24,7 @@ public class BookDataMapper {
         return new Book(
             entity.getId(),
             entity.getTitle(),
-            entity.getAuthor(),
             entity.getCoverFileName(),
-            entity.getStatus(),
             entity.getCreatedAt(),
             entity.getGenres() == null ? Collections.emptySet() :
                 entity.getGenres().stream().map(genreDataMapper::toDomain).collect(Collectors.toSet()),
@@ -55,9 +50,7 @@ public class BookDataMapper {
         BookEntity entity = new BookEntity();
         entity.setId(book.id());
         entity.setTitle(book.title());
-        entity.setAuthor(book.author());
         entity.setCoverFileName(book.coverFileName());
-        entity.setStatus(book.status());
         entity.setCreatedAt(book.createdAt());
         entity.setGenres(book.genres() == null ? Collections.emptySet() :
             book.genres().stream().map(genreDataMapper::toEntity).collect(Collectors.toSet()));
@@ -74,16 +67,6 @@ public class BookDataMapper {
             book.attempts().stream().map(readingAttemptDataMapper::toEntity).toList());
         entity.setNotes(book.notes() == null ? List.of() :
             book.notes().stream().map(noteDataMapper::toEntity).toList());
-        return entity;
-    }
-
-    public BookEntity toEntity(BookCreation data, Set<GenreEntity> genres) {
-        if (data == null) return null;
-
-        BookEntity entity = new BookEntity();
-        entity.setTitle(data.title());
-        entity.setAuthor(data.author());
-        entity.setGenres(genres);
         return entity;
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/Book.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/Book.java
@@ -1,6 +1,5 @@
 package ru.jerael.booktracker.backend.domain.model.book;
 
-import jakarta.annotation.Nullable;
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.author.Author;
 import ru.jerael.booktracker.backend.domain.model.language.Language;
@@ -9,6 +8,7 @@ import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
 import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -16,19 +16,28 @@ import java.util.UUID;
 public record Book(
     UUID id,
     String title,
-    String author,
-    @Nullable String coverFileName,
-    BookStatus status,
+    String coverFileName,
     Instant createdAt,
     Set<Genre> genres,
     Set<Author> authors,
-    @Nullable String description,
-    @Nullable Publisher publisher,
-    @Nullable Language language,
-    @Nullable LocalDate publishedOn,
-    @Nullable Integer totalPages,
-    @Nullable String isbn10,
-    @Nullable String isbn13,
+    String description,
+    Publisher publisher,
+    Language language,
+    LocalDate publishedOn,
+    Integer totalPages,
+    String isbn10,
+    String isbn13,
     List<ReadingAttempt> attempts,
     List<Note> notes
-) {}
+) {
+    public BookStatus status() {
+        if (attempts == null || attempts.isEmpty()) {
+            return BookStatus.defaultStatus();
+        }
+
+        return attempts.stream()
+            .max(Comparator.comparing(ReadingAttempt::startedAt))
+            .map(ReadingAttempt::status)
+            .orElse(BookStatus.defaultStatus());
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookStatus.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookStatus.java
@@ -26,4 +26,8 @@ public enum BookStatus {
         }
         throw BookExceptionFactory.invalidStatus(value);
     }
+
+    public static BookStatus defaultStatus() {
+        return BookStatus.WANT_TO_READ;
+    }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/dto/book/BookResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/dto/book/BookResponse.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 public record BookResponse(
     UUID id,
     String title,
-    String author,
 
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @Nullable

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapper.java
@@ -35,7 +35,6 @@ public class BookWebMapper {
         return new BookResponse(
             book.id(),
             book.title(),
-            book.author(),
             coverUrl,
             book.status().getValue(),
             book.createdAt(),

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -59,3 +59,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/29__fill-publisher_id-and-language_code-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/30__drop-unique-constraint-for-isbn.yaml
+  - include:
+      file: classpath:/db/changelog/changes/31__drop-deprecated-fields-in-books.yaml

--- a/src/main/resources/db/changelog/changes/31__drop-deprecated-fields-in-books.yaml
+++ b/src/main/resources/db/changelog/changes/31__drop-deprecated-fields-in-books.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 31__drop-deprecated-fields-in-books
+      author: Jerael
+      comment: drop deprecated fields in books
+      changes:
+        - dropColumn:
+            tableName: books
+            columns:
+              - column:
+                  name: author
+              - column:
+                  name: status

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
@@ -40,7 +40,7 @@ class CreateBookUseCaseImplTest {
 
         String title = "title";
         String author = "author";
-        BookStatus status = BookStatus.READING;
+        BookStatus status = BookStatus.WANT_TO_READ;
         Set<Integer> genreIds = Set.of(1, 2);
         BookCreation data = new BookCreation(title, author, status, genreIds);
 
@@ -54,9 +54,7 @@ class CreateBookUseCaseImplTest {
             return new Book(
                 id,
                 book.title(),
-                book.author(),
                 book.coverFileName(),
-                book.status(),
                 book.createdAt(),
                 book.genres(),
                 Set.of(),

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.storage.BookCoverStorage;
 import java.time.Instant;
@@ -30,8 +29,6 @@ class DeleteBookUseCaseImplTest {
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
-    private final String author = "author";
-    private final BookStatus status = BookStatus.WANT_TO_READ;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
 
     @Test
@@ -49,9 +46,7 @@ class DeleteBookUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             coverFileName,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -78,9 +73,7 @@ class DeleteBookUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
@@ -30,8 +30,6 @@ class DeleteCoverUseCaseImplTest {
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
-    private final String author = "author";
-    private final BookStatus status = BookStatus.WANT_TO_READ;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
 
     @Test
@@ -49,9 +47,7 @@ class DeleteCoverUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             coverFileName,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -72,9 +68,7 @@ class DeleteCoverUseCaseImplTest {
         Book updatedBook = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -97,9 +91,7 @@ class DeleteCoverUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
@@ -35,8 +35,6 @@ class GetBookByIdUseCaseImplTest {
     void execute_WhenBookExists_ShouldReturnBook() {
         UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
         String title = "title";
-        String author = "author";
-        BookStatus status = BookStatus.READING;
         Instant createdAt = Instant.ofEpochMilli(1771249699347L);
         Genre genre1 = new Genre(1, "action");
         Genre genre2 = new Genre(2, "adventure");
@@ -44,9 +42,7 @@ class GetBookByIdUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             genres,
             Set.of(),

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
@@ -33,8 +33,6 @@ class GetBookCoverUseCaseImplTest {
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
-    private final String author = "author";
-    private final BookStatus status = BookStatus.READING;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
 
     @Test
@@ -50,9 +48,7 @@ class GetBookCoverUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             coverFileName,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -89,9 +85,7 @@ class GetBookCoverUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
@@ -9,7 +9,6 @@ import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import ru.jerael.booktracker.backend.domain.model.book.BookDetailsUpdate;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
 import java.time.Instant;
@@ -37,15 +36,11 @@ class UpdateBookDetailsUseCaseImplTest {
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
-    private final String author = "author";
-    private final BookStatus status = BookStatus.WANT_TO_READ;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
     private final Book book = new Book(
         id,
         title,
-        author,
         null,
-        status,
         createdAt,
         Collections.emptySet(),
         Set.of(),
@@ -83,8 +78,6 @@ class UpdateBookDetailsUseCaseImplTest {
         Book updatedBook = useCase.execute(id, userId, data);
 
         assertEquals("new title", updatedBook.title());
-        assertEquals(author, updatedBook.author());
-        assertEquals(status, updatedBook.status());
         assertThat(updatedBook.genres()).containsExactly(genre);
         verify(bookRepository).save(any(), eq(userId));
     }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import ru.jerael.booktracker.backend.domain.exception.NotFoundException;
 import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.book.UploadCover;
 import ru.jerael.booktracker.backend.domain.model.image.ImageFile;
 import ru.jerael.booktracker.backend.domain.model.image.ProcessedImage;
@@ -43,15 +42,11 @@ class UploadCoverUseCaseImplTest {
 
     private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
-    private final String author = "author";
-    private final BookStatus status = BookStatus.WANT_TO_READ;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
     private final Book book = new Book(
         id,
         title,
-        author,
         null,
-        status,
         createdAt,
         Collections.emptySet(),
         Set.of(),
@@ -120,9 +115,7 @@ class UploadCoverUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             oldCoverFileName,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -155,9 +148,7 @@ class UploadCoverUseCaseImplTest {
         Book book = new Book(
             id,
             title,
-            author,
             oldCoverFileName,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapperTest.java
@@ -2,13 +2,9 @@ package ru.jerael.booktracker.backend.data.mapper;
 
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
-import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
-import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -31,9 +27,7 @@ class BookDataMapperTest {
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final String title = "title";
-    private final String author = "author";
     private final String coverFileName = null;
-    private final BookStatus status = BookStatus.READING;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
     private final Genre genre1 = new Genre(1, "action");
     private final Genre genre2 = new Genre(2, "adventure");
@@ -41,9 +35,7 @@ class BookDataMapperTest {
     private final Book book = new Book(
         id,
         title,
-        author,
         coverFileName,
-        status,
         createdAt,
         genres,
         Set.of(),
@@ -63,9 +55,7 @@ class BookDataMapperTest {
         BookEntity entity = new BookEntity();
         entity.setId(id);
         entity.setTitle(title);
-        entity.setAuthor(author);
         entity.setCoverFileName(coverFileName);
-        entity.setStatus(status);
         entity.setCreatedAt(createdAt);
         entity.setGenres(genres.stream().map(genreDataMapper::toEntity).collect(Collectors.toSet()));
 
@@ -81,17 +71,5 @@ class BookDataMapperTest {
 
         assertEquals(id, entity.getId());
         assertEquals(title, entity.getTitle());
-    }
-
-    @Test
-    void creation_toEntity() {
-        BookCreation data = new BookCreation(title, author, null, Collections.emptySet());
-        Set<GenreEntity> entities = genres.stream().map(genreDataMapper::toEntity).collect(Collectors.toSet());
-
-        BookEntity entity = bookDataMapper.toEntity(data, entities);
-
-        assertEquals(title, entity.getTitle());
-        assertEquals(author, entity.getAuthor());
-        assertEquals(entities.size(), entity.getGenres().size());
     }
 }

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapperTest.java
@@ -3,7 +3,6 @@ package ru.jerael.booktracker.backend.data.mapper;
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.note.Note;
 import ru.jerael.booktracker.backend.domain.model.note.NoteType;
 import java.time.Instant;
@@ -44,9 +43,7 @@ class NoteDataMapperTest {
         book.setId(bookId);
         book.setUserId(userId);
         book.setTitle("title");
-        book.setAuthor("author");
         book.setCoverFileName(null);
-        book.setStatus(BookStatus.WANT_TO_READ);
         book.setCreatedAt(Instant.now());
         book.setGenres(Collections.emptySet());
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
@@ -48,9 +48,7 @@ class ReadingAttemptDataMapperTest {
         book.setId(bookId);
         book.setUserId(userId);
         book.setTitle("title");
-        book.setAuthor("author");
         book.setCoverFileName(null);
-        book.setStatus(BookStatus.WANT_TO_READ);
         book.setCreatedAt(Instant.now());
         book.setGenres(Collections.emptySet());
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
@@ -11,7 +11,6 @@ import ru.jerael.booktracker.backend.data.db.repository.JpaGenreRepository;
 import ru.jerael.booktracker.backend.data.mapper.*;
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
 import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
 import ru.jerael.booktracker.backend.domain.model.pagination.SortDirection;
@@ -57,16 +56,12 @@ class BookRepositoryImplTest {
 
         BookEntity book1 = new BookEntity();
         book1.setTitle("title");
-        book1.setAuthor("author");
-        book1.setStatus(BookStatus.READING);
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(new HashSet<>(genres));
         book1.setUserId(userId);
 
         BookEntity book2 = new BookEntity();
         book2.setTitle("asd");
-        book2.setAuthor("dsa");
-        book2.setStatus(BookStatus.WANT_TO_READ);
         book2.setCreatedAt(Instant.ofEpochMilli(177124961234L));
         book2.setGenres(Collections.emptySet());
         book2.setUserId(userId);
@@ -95,8 +90,6 @@ class BookRepositoryImplTest {
 
         BookEntity book1 = new BookEntity();
         book1.setTitle("title");
-        book1.setAuthor("author");
-        book1.setStatus(BookStatus.READING);
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(Set.of(savedGenre));
         book1.setUserId(userId);
@@ -128,9 +121,7 @@ class BookRepositoryImplTest {
         Book book = new Book(
             null,
             title,
-            author,
             null,
-            BookStatus.WANT_TO_READ,
             Instant.now(),
             genres,
             Set.of(),
@@ -149,7 +140,6 @@ class BookRepositoryImplTest {
 
         assertNotNull(createdBook.id());
         assertEquals(title, createdBook.title());
-        assertEquals(author, createdBook.author());
         assertEquals(2, createdBook.genres().size());
         assertTrue(jpaBookRepository.existsById(createdBook.id()));
     }
@@ -158,9 +148,7 @@ class BookRepositoryImplTest {
     void save_WhenIdIsPresent_ShouldUpdateExistingBook() {
         BookEntity bookEntity = new BookEntity();
         bookEntity.setTitle("title");
-        bookEntity.setAuthor("author");
         bookEntity.setCoverFileName("old_cover.jpg");
-        bookEntity.setStatus(BookStatus.READING);
         bookEntity.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         bookEntity.setGenres(Collections.emptySet());
 
@@ -169,9 +157,7 @@ class BookRepositoryImplTest {
         Book book = new Book(
             id,
             "new title",
-            "new author",
             "new_cover.jpg",
-            savedBook.getStatus(),
             savedBook.getCreatedAt(),
             Collections.emptySet(),
             Set.of(),
@@ -193,7 +179,6 @@ class BookRepositoryImplTest {
 
         BookEntity entity = jpaBookRepository.findById(id).orElseThrow();
         assertEquals("new title", entity.getTitle());
-        assertEquals("new author", entity.getAuthor());
     }
 
     @Test
@@ -213,9 +198,7 @@ class BookRepositoryImplTest {
         Book book = new Book(
             null,
             title,
-            author,
             null,
-            BookStatus.WANT_TO_READ,
             Instant.now(),
             genres,
             Set.of(),
@@ -234,7 +217,6 @@ class BookRepositoryImplTest {
 
         assertNotNull(createdBook.id());
         assertEquals(title, createdBook.title());
-        assertEquals(author, createdBook.author());
         assertEquals(2, createdBook.genres().size());
         assertTrue(jpaBookRepository.existsById(createdBook.id()));
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImplTest.java
@@ -11,7 +11,6 @@ import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaNoteRepository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaUserRepository;
 import ru.jerael.booktracker.backend.data.mapper.NoteDataMapper;
-import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.note.Note;
 import ru.jerael.booktracker.backend.domain.model.note.NoteType;
 import java.time.Instant;
@@ -102,9 +101,7 @@ class NoteRepositoryImplTest {
         BookEntity entity = new BookEntity();
         entity.setUserId(userId);
         entity.setTitle("title");
-        entity.setAuthor("author");
         entity.setCoverFileName(null);
-        entity.setStatus(BookStatus.WANT_TO_READ);
         entity.setCreatedAt(Instant.now());
         entity.setGenres(Collections.emptySet());
         return jpaBookRepository.save(entity);

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
@@ -120,9 +120,7 @@ class ReadingAttemptRepositoryImplTest {
         BookEntity entity = new BookEntity();
         entity.setUserId(userId);
         entity.setTitle("title");
-        entity.setAuthor("author");
         entity.setCoverFileName(null);
-        entity.setStatus(BookStatus.WANT_TO_READ);
         entity.setCreatedAt(Instant.now());
         entity.setGenres(Collections.emptySet());
         return jpaBookRepository.save(entity);

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImplTest.java
@@ -102,9 +102,7 @@ class ReadingSessionRepositoryImplTest {
         BookEntity entity = new BookEntity();
         entity.setUserId(userId);
         entity.setTitle("title");
-        entity.setAuthor("author");
         entity.setCoverFileName(null);
-        entity.setStatus(BookStatus.WANT_TO_READ);
         entity.setCreatedAt(Instant.now());
         entity.setGenres(Collections.emptySet());
         return jpaBookRepository.save(entity);

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -107,9 +107,7 @@ class BookControllerTest {
         Book book = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -126,7 +124,6 @@ class BookControllerTest {
         BookResponse bookResponse = new BookResponse(
             id,
             title,
-            author,
             null,
             status.getValue(),
             createdAt,
@@ -193,16 +190,14 @@ class BookControllerTest {
         BookDetailsUpdateRequest request = new BookDetailsUpdateRequest(
             "new title",
             null,
-            "reading",
+            "want_to_read",
             null
         );
-        BookDetailsUpdate data = new BookDetailsUpdate("new title", null, BookStatus.READING, null);
+        BookDetailsUpdate data = new BookDetailsUpdate("new title", null, BookStatus.WANT_TO_READ, null);
         Book book = new Book(
             id,
             "new title",
-            author,
             null,
-            BookStatus.READING,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -219,9 +214,8 @@ class BookControllerTest {
         BookResponse bookResponse = new BookResponse(
             id,
             "new title",
-            author,
             null,
-            "reading",
+            "want_to_read",
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -250,7 +244,6 @@ class BookControllerTest {
             .convertTo(BookResponse.class)
             .satisfies(response -> {
                 assertThat(response.title()).isEqualTo(request.title());
-                assertThat(response.author()).isEqualTo(author);
                 assertThat(response.status()).isEqualTo(book.status().getValue());
             });
     }
@@ -262,9 +255,7 @@ class BookControllerTest {
         Book book = new Book(
             id,
             title,
-            author,
             null,
-            status,
             createdAt,
             Collections.emptySet(),
             Set.of(),
@@ -281,7 +272,6 @@ class BookControllerTest {
         BookResponse bookResponse = new BookResponse(
             id,
             title,
-            author,
             null,
             status.getValue(),
             createdAt,
@@ -313,7 +303,6 @@ class BookControllerTest {
             .satisfies(response -> {
                     assertThat(response.id()).isEqualTo(bookResponse.id());
                     assertThat(response.title()).isEqualTo(bookResponse.title());
-                    assertThat(response.author()).isEqualTo(bookResponse.author());
                 }
             );
     }
@@ -331,9 +320,7 @@ class BookControllerTest {
         Book book = new Book(
             id,
             title,
-            author,
             coverFileName,
-            status,
             createdAt,
             null,
             Set.of(),
@@ -350,7 +337,6 @@ class BookControllerTest {
         BookResponse bookResponse = new BookResponse(
             id,
             title,
-            author,
             coverFileName,
             status.getValue(),
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
@@ -35,9 +35,7 @@ class BookWebMapperTest {
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
     private final String title = "title";
-    private final String author = "author";
     private final String coverFileName = "cover.jpg";
-    private final BookStatus status = BookStatus.READING;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
     private final Genre genre1 = new Genre(1, "action");
     private final Genre genre2 = new Genre(2, "adventure");
@@ -45,9 +43,7 @@ class BookWebMapperTest {
     private final Book book = new Book(
         id,
         title,
-        author,
         coverFileName,
-        status,
         createdAt,
         genres,
         Set.of(),
@@ -71,9 +67,8 @@ class BookWebMapperTest {
 
         assertEquals(id, bookResponse.id());
         assertEquals(title, bookResponse.title());
-        assertEquals(author, bookResponse.author());
         assertEquals(coverUrl, bookResponse.coverUrl());
-        assertEquals(status.getValue(), bookResponse.status());
+        assertEquals(BookStatus.defaultStatus().getValue(), bookResponse.status());
         assertEquals(createdAt, bookResponse.createdAt());
         assertTrue(bookResponse.genres().containsAll(genreWebMapper.toResponses(genres)));
     }
@@ -84,9 +79,7 @@ class BookWebMapperTest {
         Book book2 = new Book(
             id2,
             "asd",
-            author,
             coverFileName,
-            status,
             createdAt,
             genres,
             Set.of(),

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -45,3 +45,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/24__set-finished_at-nullable-in-reading_sessions.yaml
   - include:
       file: classpath:/db/changelog/changes/30__drop-unique-constraint-for-isbn.yaml
+  - include:
+      file: classpath:/db/changelog/changes/31__drop-deprecated-fields-in-books.yaml


### PR DESCRIPTION
### What does this PR do?

- Added migration with drop `author` and `status` columns from `books` table.
- Removed `author` and `status` fields from `BookEntity`, `Book` and `BookResponse` models.

Tests:
- Fixed tests.

### Related tickets

Part of #113

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
