### PR TITLE
refactor: add relationship to BookEntity and userId to Book model

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -36,6 +36,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
         // TODO: provide real data when BookCreation will be updated
         Book newBook = new Book(
             null,
+            userId,
             data.title(),
             null,
             Instant.now(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImpl.java
@@ -25,6 +25,7 @@ public class DeleteCoverUseCaseImpl implements DeleteCoverUseCase {
 
         Book updatedBook = new Book(
             book.id(),
+            userId,
             book.title(),
             null,
             book.createdAt(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
@@ -42,6 +42,7 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
         // TODO: provide real data when BookDetailsUpdate will be updated
         Book updatedBook = new Book(
             book.id(),
+            userId,
             data.title() != null ? data.title().trim() : book.title(),
             book.coverFileName(),
             book.createdAt(),

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImpl.java
@@ -53,6 +53,7 @@ public class UploadCoverUseCaseImpl implements UploadCoverUseCase {
 
         Book updatedBook = new Book(
             book.id(),
+            userId,
             book.title(),
             newCoverFileName,
             book.createdAt(),

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/BookEntity.java
@@ -21,8 +21,9 @@ public class BookEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(name = "user_id", nullable = false)
-    private UUID userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(name = "title", length = BookRules.TITLE_MAX_LENGTH, nullable = false)
     private String title;

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapper.java
@@ -3,6 +3,7 @@ package ru.jerael.booktracker.backend.data.mapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +24,7 @@ public class BookDataMapper {
 
         return new Book(
             entity.getId(),
+            entity.getUser().getId(),
             entity.getTitle(),
             entity.getCoverFileName(),
             entity.getCreatedAt(),
@@ -49,6 +51,11 @@ public class BookDataMapper {
 
         BookEntity entity = new BookEntity();
         entity.setId(book.id());
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(book.userId());
+        entity.setUser(userEntity);
+
         entity.setTitle(book.title());
         entity.setCoverFileName(book.coverFileName());
         entity.setCreatedAt(book.createdAt());

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImpl.java
@@ -52,7 +52,6 @@ public class BookRepositoryImpl implements BookRepository {
     @Override
     public Book save(Book book, UUID userId) {
         BookEntity entity = bookDataMapper.toEntity(book);
-        entity.setUserId(userId);
         BookEntity savedEntity = jpaBookRepository.save(entity);
         return bookDataMapper.toDomain(savedEntity);
     }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/Book.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/Book.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 
 public record Book(
     UUID id,
+    UUID userId,
     String title,
     String coverFileName,
     Instant createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
@@ -53,6 +53,7 @@ class CreateBookUseCaseImplTest {
             Book book = invocationOnMock.getArgument(0);
             return new Book(
                 id,
+                userId,
                 book.title(),
                 book.coverFileName(),
                 book.createdAt(),

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteBookUseCaseImplTest.java
@@ -45,6 +45,7 @@ class DeleteBookUseCaseImplTest {
         String coverFileName = "cover.jpg";
         Book book = new Book(
             id,
+            userId,
             title,
             coverFileName,
             createdAt,
@@ -72,6 +73,7 @@ class DeleteBookUseCaseImplTest {
     void execute_WhenBookHasNotCover_ShouldDeleteOnlyBook() {
         Book book = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/DeleteCoverUseCaseImplTest.java
@@ -46,6 +46,7 @@ class DeleteCoverUseCaseImplTest {
         String coverFileName = "cover.jpg";
         Book book = new Book(
             id,
+            userId,
             title,
             coverFileName,
             createdAt,
@@ -67,6 +68,7 @@ class DeleteCoverUseCaseImplTest {
 
         Book updatedBook = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,
@@ -90,6 +92,7 @@ class DeleteCoverUseCaseImplTest {
     void execute_WhenCoverDoesNotExists_ShouldExitWithoutUpdate() {
         Book book = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookByIdUseCaseImplTest.java
@@ -41,6 +41,7 @@ class GetBookByIdUseCaseImplTest {
         Set<Genre> genres = Set.of(genre1, genre2);
         Book book = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/GetBookCoverUseCaseImplTest.java
@@ -47,6 +47,7 @@ class GetBookCoverUseCaseImplTest {
         );
         Book book = new Book(
             id,
+            userId,
             title,
             coverFileName,
             createdAt,
@@ -84,6 +85,7 @@ class GetBookCoverUseCaseImplTest {
     void execute_WhenCoverDoesNotExists_ShouldThrowNotFoundException() {
         Book book = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImplTest.java
@@ -39,6 +39,7 @@ class UpdateBookDetailsUseCaseImplTest {
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
     private final Book book = new Book(
         id,
+        userId,
         title,
         null,
         createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/UploadCoverUseCaseImplTest.java
@@ -45,6 +45,7 @@ class UploadCoverUseCaseImplTest {
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
     private final Book book = new Book(
         id,
+        userId,
         title,
         null,
         createdAt,
@@ -114,6 +115,7 @@ class UploadCoverUseCaseImplTest {
         String newCoverFileName = id + ".jpg";
         Book book = new Book(
             id,
+            userId,
             title,
             oldCoverFileName,
             createdAt,
@@ -147,6 +149,7 @@ class UploadCoverUseCaseImplTest {
         String oldCoverFileName = "old_cover.jpg";
         Book book = new Book(
             id,
+            userId,
             title,
             oldCoverFileName,
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/BookDataMapperTest.java
@@ -2,6 +2,7 @@ package ru.jerael.booktracker.backend.data.mapper;
 
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.domain.model.Genre;
 import ru.jerael.booktracker.backend.domain.model.book.Book;
 import java.time.Instant;
@@ -26,6 +27,7 @@ class BookDataMapperTest {
     );
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
     private final String coverFileName = null;
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
@@ -34,6 +36,7 @@ class BookDataMapperTest {
     private final Set<Genre> genres = Set.of(genre1, genre2);
     private final Book book = new Book(
         id,
+        userId,
         title,
         coverFileName,
         createdAt,
@@ -54,6 +57,11 @@ class BookDataMapperTest {
     void entity_toDomain() {
         BookEntity entity = new BookEntity();
         entity.setId(id);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        entity.setUser(userEntity);
+
         entity.setTitle(title);
         entity.setCoverFileName(coverFileName);
         entity.setCreatedAt(createdAt);

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/NoteDataMapperTest.java
@@ -3,6 +3,7 @@ package ru.jerael.booktracker.backend.data.mapper;
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.NoteEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.domain.model.note.Note;
 import ru.jerael.booktracker.backend.domain.model.note.NoteType;
 import java.time.Instant;
@@ -41,7 +42,11 @@ class NoteDataMapperTest {
     void toDomain() {
         BookEntity book = new BookEntity();
         book.setId(bookId);
-        book.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        book.setUser(userEntity);
+
         book.setTitle("title");
         book.setCoverFileName(null);
         book.setCreatedAt(Instant.now());

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/ReadingAttemptDataMapperTest.java
@@ -3,6 +3,7 @@ package ru.jerael.booktracker.backend.data.mapper;
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.ReadingAttemptEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt;
 import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
@@ -46,7 +47,11 @@ class ReadingAttemptDataMapperTest {
     void toDomain() {
         BookEntity book = new BookEntity();
         book.setId(bookId);
-        book.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        book.setUser(userEntity);
+
         book.setTitle("title");
         book.setCoverFileName(null);
         book.setCreatedAt(Instant.now());

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/BookRepositoryImplTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import ru.jerael.booktracker.backend.data.db.entity.BookEntity;
 import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.data.db.repository.JpaBookRepository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaGenreRepository;
 import ru.jerael.booktracker.backend.data.mapper.*;
@@ -58,13 +59,16 @@ class BookRepositoryImplTest {
         book1.setTitle("title");
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(new HashSet<>(genres));
-        book1.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        book1.setUser(userEntity);
 
         BookEntity book2 = new BookEntity();
         book2.setTitle("asd");
         book2.setCreatedAt(Instant.ofEpochMilli(177124961234L));
         book2.setGenres(Collections.emptySet());
-        book2.setUserId(userId);
+        book2.setUser(userEntity);
 
         List<BookEntity> entities = jpaBookRepository.saveAll(List.of(book1, book2));
         UUID id1 = entities.get(0).getId();
@@ -92,7 +96,10 @@ class BookRepositoryImplTest {
         book1.setTitle("title");
         book1.setCreatedAt(Instant.ofEpochMilli(1771249699347L));
         book1.setGenres(Set.of(savedGenre));
-        book1.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        book1.setUser(userEntity);
 
         BookEntity savedBook = jpaBookRepository.save(book1);
         UUID id = savedBook.getId();
@@ -117,9 +124,9 @@ class BookRepositoryImplTest {
             .collect(Collectors.toSet());
 
         String title = "title";
-        String author = "author";
         Book book = new Book(
             null,
+            userId,
             title,
             null,
             Instant.now(),
@@ -156,6 +163,7 @@ class BookRepositoryImplTest {
         UUID id = savedBook.getId();
         Book book = new Book(
             id,
+            userId,
             "new title",
             "new_cover.jpg",
             savedBook.getCreatedAt(),
@@ -194,9 +202,9 @@ class BookRepositoryImplTest {
             .collect(Collectors.toSet());
 
         String title = "title";
-        String author = "author";
         Book book = new Book(
             null,
+            userId,
             title,
             null,
             Instant.now(),

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/NoteRepositoryImplTest.java
@@ -99,7 +99,11 @@ class NoteRepositoryImplTest {
 
     private BookEntity saveBook(UUID userId) {
         BookEntity entity = new BookEntity();
-        entity.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        entity.setUser(userEntity);
+
         entity.setTitle("title");
         entity.setCoverFileName(null);
         entity.setCreatedAt(Instant.now());

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
@@ -118,7 +118,11 @@ class ReadingAttemptRepositoryImplTest {
 
     private BookEntity saveBook(UUID userId) {
         BookEntity entity = new BookEntity();
-        entity.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        entity.setUser(userEntity);
+
         entity.setTitle("title");
         entity.setCoverFileName(null);
         entity.setCreatedAt(Instant.now());

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingSessionRepositoryImplTest.java
@@ -100,7 +100,11 @@ class ReadingSessionRepositoryImplTest {
 
     private BookEntity saveBook(UUID userId) {
         BookEntity entity = new BookEntity();
-        entity.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        entity.setUser(userEntity);
+
         entity.setTitle("title");
         entity.setCoverFileName(null);
         entity.setCreatedAt(Instant.now());

--- a/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/controller/BookControllerTest.java
@@ -106,6 +106,7 @@ class BookControllerTest {
     void getAll_ShouldReturnListOfBookResponses() {
         Book book = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,
@@ -196,6 +197,7 @@ class BookControllerTest {
         BookDetailsUpdate data = new BookDetailsUpdate("new title", null, BookStatus.WANT_TO_READ, null);
         Book book = new Book(
             id,
+            userId,
             "new title",
             null,
             createdAt,
@@ -254,6 +256,7 @@ class BookControllerTest {
         BookCreation data = new BookCreation(title, author, null, Set.of(1, 2));
         Book book = new Book(
             id,
+            userId,
             title,
             null,
             createdAt,
@@ -319,6 +322,7 @@ class BookControllerTest {
         UploadCover data = new UploadCover(MediaType.IMAGE_JPEG_VALUE, null, 0L);
         Book book = new Book(
             id,
+            userId,
             title,
             coverFileName,
             createdAt,

--- a/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/web/mapper/BookWebMapperTest.java
@@ -34,6 +34,7 @@ class BookWebMapperTest {
             readingAttemptWebMapper, noteWebMapper, linkBuilder);
 
     private final UUID id = UUID.fromString("ee39af7a-a073-4473-878a-1aae34e98bb7");
+    private final UUID userId = UUID.fromString("2c5781ea-1bc2-4561-a83d-26106df2526e");
     private final String title = "title";
     private final String coverFileName = "cover.jpg";
     private final Instant createdAt = Instant.ofEpochMilli(1771249699347L);
@@ -42,6 +43,7 @@ class BookWebMapperTest {
     private final Set<Genre> genres = Set.of(genre1, genre2);
     private final Book book = new Book(
         id,
+        userId,
         title,
         coverFileName,
         createdAt,
@@ -78,6 +80,7 @@ class BookWebMapperTest {
         UUID id2 = UUID.fromString("31d3f5e3-7faf-4678-a3cf-4657d8875a82");
         Book book2 = new Book(
             id2,
+            userId,
             "asd",
             coverFileName,
             createdAt,


### PR DESCRIPTION
### What does this PR do?

- Refactored `userId` field to Many-to-One relationship in `BookEntity`.
- Added `userId` field to `Book` model.

Tests:
- Updated tests.

### Related tickets

Part of #113

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
