### PR TITLE
refactor: add relationship to RefreshTokenEntity

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/db/entity/RefreshTokenEntity.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/entity/RefreshTokenEntity.java
@@ -20,8 +20,9 @@ public class RefreshTokenEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(name = "user_id", nullable = false)
-    private UUID userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
     @Column(name = "token_hash", length = AuthRules.REFRESH_TOKEN_HASH_MAX_LENGTH, nullable = false)
     private String tokenHash;

--- a/src/main/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapper.java
@@ -2,6 +2,7 @@ package ru.jerael.booktracker.backend.data.mapper;
 
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
 
 @Component
@@ -11,7 +12,11 @@ public class RefreshTokenDataMapper {
 
         RefreshTokenEntity entity = new RefreshTokenEntity();
         entity.setId(refreshToken.id());
-        entity.setUserId(refreshToken.userId());
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(refreshToken.userId());
+        entity.setUser(userEntity);
+
         entity.setTokenHash(refreshToken.tokenHash());
         entity.setExpiresAt(refreshToken.expiresAt());
         return entity;
@@ -22,7 +27,7 @@ public class RefreshTokenDataMapper {
 
         return new RefreshToken(
             entity.getId(),
-            entity.getUserId(),
+            entity.getUser().getId(),
             entity.getTokenHash(),
             entity.getExpiresAt()
         );

--- a/src/test/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapperTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/mapper/RefreshTokenDataMapperTest.java
@@ -2,6 +2,7 @@ package ru.jerael.booktracker.backend.data.mapper;
 
 import org.junit.jupiter.api.Test;
 import ru.jerael.booktracker.backend.data.db.entity.RefreshTokenEntity;
+import ru.jerael.booktracker.backend.data.db.entity.UserEntity;
 import ru.jerael.booktracker.backend.domain.model.auth.RefreshToken;
 import java.time.Instant;
 import java.util.UUID;
@@ -22,7 +23,7 @@ class RefreshTokenDataMapperTest {
         RefreshTokenEntity entity = refreshTokenDataMapper.toEntity(refreshToken);
 
         assertEquals(id, entity.getId());
-        assertEquals(userId, entity.getUserId());
+        assertEquals(userId, entity.getUser().getId());
         assertEquals(tokenHash, entity.getTokenHash());
         assertEquals(expiresAt, entity.getExpiresAt());
     }
@@ -31,7 +32,11 @@ class RefreshTokenDataMapperTest {
     void toDomain() {
         RefreshTokenEntity entity = new RefreshTokenEntity();
         entity.setId(id);
-        entity.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        entity.setUser(userEntity);
+
         entity.setTokenHash(tokenHash);
         entity.setExpiresAt(expiresAt);
 

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/RefreshTokenRepositoryImplTest.java
@@ -44,7 +44,7 @@ class RefreshTokenRepositoryImplTest {
         assertEquals(1, entities.size());
 
         RefreshTokenEntity entity = entities.get(0);
-        assertEquals(userId, entity.getUserId());
+        assertEquals(userId, entity.getUser().getId());
         assertEquals(tokenHash, entity.getTokenHash());
         assertEquals(expiresAt, entity.getExpiresAt());
     }
@@ -91,7 +91,11 @@ class RefreshTokenRepositoryImplTest {
 
     private RefreshTokenEntity saveEntity(UUID userId, String hash) {
         RefreshTokenEntity entity = new RefreshTokenEntity();
-        entity.setUserId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        entity.setUser(userEntity);
+
         entity.setTokenHash(hash);
         entity.setExpiresAt(expiresAt);
         return jpaRefreshTokenRepository.save(entity);


### PR DESCRIPTION
### What does this PR do?

- Refactored `userId` field to Many-to-One relationship in `RefreshTokenEntity`.
- Updated `RefreshTokenDataMapper`.

Tests:
- Updated tests.

### Related tickets

Part of #113

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
