### PR TITLE
refactor: remove nullable annotations in domain models

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookCreation.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookCreation.java
@@ -1,11 +1,10 @@
 package ru.jerael.booktracker.backend.domain.model.book;
 
-import jakarta.annotation.Nullable;
 import java.util.Set;
 
 public record BookCreation(
     String title,
     String author,
-    @Nullable BookStatus status,
+    BookStatus status,
     Set<Integer> genreIds
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookDetailsUpdate.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookDetailsUpdate.java
@@ -1,11 +1,10 @@
 package ru.jerael.booktracker.backend.domain.model.book;
 
-import jakarta.annotation.Nullable;
 import java.util.Set;
 
 public record BookDetailsUpdate(
-    @Nullable String title,
-    @Nullable String author,
-    @Nullable BookStatus status,
-    @Nullable Set<Integer> genreIds
+    String title,
+    String author,
+    BookStatus status,
+    Set<Integer> genreIds
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/note/Note.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/note/Note.java
@@ -1,6 +1,5 @@
 package ru.jerael.booktracker.backend.domain.model.note;
 
-import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -8,8 +7,8 @@ public record Note(
     UUID id,
     UUID bookId,
     NoteType type,
-    @Nullable String textContent,
-    @Nullable String fileName,
+    String textContent,
+    String fileName,
     int pageNumber,
     Instant createdAt
 ) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_attempt/ReadingAttempt.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/reading_attempt/ReadingAttempt.java
@@ -1,6 +1,5 @@
 package ru.jerael.booktracker.backend.domain.model.reading_attempt;
 
-import jakarta.annotation.Nullable;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
 import java.time.Instant;
@@ -12,6 +11,6 @@ public record ReadingAttempt(
     UUID bookId,
     BookStatus status,
     Instant startedAt,
-    @Nullable Instant finishedAt,
+    Instant finishedAt,
     List<ReadingSession> sessions
 ) {}


### PR DESCRIPTION
### What does this PR do?

- Removed `Nullable` annotations in `BookCreation`, `BookDetailsUpdate`, `Note` and `ReadingAttempt` domain models.

### Related tickets

no related ticket

### Screenshots

not applicable

### How to test

no need to test

### Additional notes

no additional info
