### PR TITLE
feat: add validator for book creation

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -16,6 +16,7 @@ import ru.jerael.booktracker.backend.domain.model.reading_attempt.ReadingAttempt
 import ru.jerael.booktracker.backend.domain.model.reading_session.ReadingSession;
 import ru.jerael.booktracker.backend.domain.repository.*;
 import ru.jerael.booktracker.backend.domain.usecase.book.CreateBookUseCase;
+import ru.jerael.booktracker.backend.domain.validator.BookValidator;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -30,10 +31,13 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
     private final AuthorRepository authorRepository;
     private final PublisherRepository publisherRepository;
     private final LanguageRepository languageRepository;
+    private final BookValidator bookValidator;
 
     @Override
     @Transactional
     public Book execute(BookCreation data) {
+        bookValidator.validateCreation(data);
+
         Set<Genre> genres = genreRepository.findAllById(data.genreIds());
         if (genres.size() != data.genreIds().size()) {
             Set<Integer> foundIds = genres.stream().map(Genre::id).collect(Collectors.toSet());

--- a/src/main/java/ru/jerael/booktracker/backend/application/validator/BookValidatorImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/validator/BookValidatorImpl.java
@@ -9,6 +9,7 @@ import ru.jerael.booktracker.backend.domain.exception.ValidationException;
 import ru.jerael.booktracker.backend.domain.exception.factory.BookErrorFactory;
 import ru.jerael.booktracker.backend.domain.exception.factory.CommonValidationErrorFactory;
 import ru.jerael.booktracker.backend.domain.exception.model.ValidationError;
+import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
 import ru.jerael.booktracker.backend.domain.model.book.BookDetailsUpdate;
 import ru.jerael.booktracker.backend.domain.validator.BookValidator;
 import java.util.ArrayList;
@@ -20,6 +21,22 @@ import java.util.stream.Collectors;
 public class BookValidatorImpl implements BookValidator {
     @Override
     public void validateUpdate(BookDetailsUpdate data) {
+        List<ValidationError> errors = new ArrayList<>();
+        errors.addAll(validateTitle(data.title()));
+        errors.addAll(validateAuthorNames(data.authorNames()));
+        errors.addAll(validateDescription(data.description()));
+        errors.addAll(validatePublisherName(data.publisherName()));
+        errors.addAll(validateLanguageCode(data.languageCode()));
+        errors.addAll(validateTotalPages(data.totalPages()));
+        errors.addAll(validateIsbn10(data.isbn10()));
+        errors.addAll(validateIsbn13(data.isbn13()));
+        if (!errors.isEmpty()) {
+            throw new ValidationException(errors);
+        }
+    }
+
+    @Override
+    public void validateCreation(BookCreation data) {
         List<ValidationError> errors = new ArrayList<>();
         errors.addAll(validateTitle(data.title()));
         errors.addAll(validateAuthorNames(data.authorNames()));

--- a/src/main/java/ru/jerael/booktracker/backend/domain/validator/BookValidator.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/validator/BookValidator.java
@@ -1,7 +1,10 @@
 package ru.jerael.booktracker.backend.domain.validator;
 
+import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
 import ru.jerael.booktracker.backend.domain.model.book.BookDetailsUpdate;
 
 public interface BookValidator {
     void validateUpdate(BookDetailsUpdate data);
+
+    void validateCreation(BookCreation data);
 }

--- a/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImplTest.java
@@ -13,6 +13,7 @@ import ru.jerael.booktracker.backend.domain.model.book.BookCreation;
 import ru.jerael.booktracker.backend.domain.model.book.BookStatus;
 import ru.jerael.booktracker.backend.domain.repository.BookRepository;
 import ru.jerael.booktracker.backend.domain.repository.GenreRepository;
+import ru.jerael.booktracker.backend.domain.validator.BookValidator;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
@@ -28,6 +29,9 @@ class CreateBookUseCaseImplTest {
 
     @Mock
     private GenreRepository genreRepository;
+
+    @Mock
+    private BookValidator bookValidator;
 
     @InjectMocks
     private CreateBookUseCaseImpl useCase;


### PR DESCRIPTION
### What does this PR do?

- Added creation validation to `BookValidator`.
- Added validation to `CreateBookUseCaseImpl`.

Tests:
- Tests will be updated in one of next issues with global tests refactoring.

### Related tickets

Closes #122

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
