### PR TITLE
feat: rename read status to completed

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/CreateBookUseCaseImpl.java
@@ -71,7 +71,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
         }
 
         List<ReadingSession> initialSessions = List.of();
-        if (data.status() == BookStatus.READ && data.totalPages() != null) {
+        if (data.status() == BookStatus.COMPLETED && data.totalPages() != null) {
             initialSessions = List.of(
                 new ReadingSession(null,
                     null,
@@ -88,7 +88,7 @@ public class CreateBookUseCaseImpl implements CreateBookUseCase {
             null,
             data.status(),
             Instant.now(),
-            data.status() == BookStatus.READ ? Instant.now() : null,
+            data.status() == BookStatus.COMPLETED ? Instant.now() : null,
             initialSessions
         );
 

--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/book/UpdateBookDetailsUseCaseImpl.java
@@ -112,14 +112,14 @@ public class UpdateBookDetailsUseCaseImpl implements UpdateBookDetailsUseCase {
         ReadingAttempt lastAttempt = attempts.get(attempts.size() - 1);
         if (lastAttempt.status() == newStatus) return attempts;
 
-        if (lastAttempt.status() == BookStatus.READ) {
+        if (lastAttempt.status() == BookStatus.COMPLETED) {
             ReadingAttempt newAttempt = new ReadingAttempt(
                 null, book.id(), newStatus, Instant.now(), null, List.of()
             );
             attempts.add(newAttempt);
         } else {
             ReadingAttempt updatedAttempt = lastAttempt.withStatus(newStatus);
-            if (newStatus == BookStatus.READ) {
+            if (newStatus == BookStatus.COMPLETED) {
                 updatedAttempt = updatedAttempt.withFinishedAt(Instant.now());
                 if (updatedAttempt.sessions().isEmpty() && book.totalPages() != null) {
                     ReadingSession finalSession = new ReadingSession(

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookStatus.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookStatus.java
@@ -5,7 +5,7 @@ import ru.jerael.booktracker.backend.domain.exception.factory.BookExceptionFacto
 public enum BookStatus {
     WANT_TO_READ("want_to_read"),
     READING("reading"),
-    READ("read");
+    COMPLETED("completed");
 
     private final String value;
 

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -63,3 +63,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/31__drop-deprecated-fields-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/32__change-published_on-type-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/33__rename-read-status-to-completed.yaml

--- a/src/main/resources/db/changelog/changes/33__rename-read-status-to-completed.yaml
+++ b/src/main/resources/db/changelog/changes/33__rename-read-status-to-completed.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 33__rename-read-status-to-completed
+      author: Jerael
+      comment: rename read status to completed
+      changes:
+        - update:
+            tableName: reading_attempts
+            where: status='READ'
+            columns:
+              - column:
+                  name: status
+                  value: COMPLETED

--- a/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
+++ b/src/test/java/ru/jerael/booktracker/backend/data/repository/ReadingAttemptRepositoryImplTest.java
@@ -55,7 +55,7 @@ class ReadingAttemptRepositoryImplTest {
         ReadingAttemptEntity entity1 = buildReadingAttemptEntity(book1, BookStatus.READING);
         jpaReadingAttemptRepository.save(entity1);
 
-        ReadingAttemptEntity entity2 = buildReadingAttemptEntity(book1, BookStatus.READ);
+        ReadingAttemptEntity entity2 = buildReadingAttemptEntity(book1, BookStatus.COMPLETED);
         jpaReadingAttemptRepository.save(entity2);
 
         ReadingAttemptEntity entity3 = buildReadingAttemptEntity(book2, BookStatus.WANT_TO_READ);
@@ -74,7 +74,7 @@ class ReadingAttemptRepositoryImplTest {
         ReadingAttemptEntity entity1 = buildReadingAttemptEntity(book, BookStatus.READING);
         jpaReadingAttemptRepository.save(entity1);
 
-        ReadingAttemptEntity entity2 = buildReadingAttemptEntity(book, BookStatus.READ);
+        ReadingAttemptEntity entity2 = buildReadingAttemptEntity(book, BookStatus.COMPLETED);
         jpaReadingAttemptRepository.save(entity2);
 
         List<ReadingAttempt> attempts =

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -49,3 +49,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/31__drop-deprecated-fields-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/32__change-published_on-type-in-books.yaml
+  - include:
+      file: classpath:/db/changelog/changes/33__rename-read-status-to-completed.yaml


### PR DESCRIPTION
### What does this PR do?

- Added migration for renaming `READ` status to `COMPLETED` in `reading_attempts` table.
- Replaced `READ` with `COMPLETED` in `BookStatus` enum.
- Updated `CreateBookUseCaseImpl` and `UpdateBookDetailsUseCaseImpl` for using new `COMPLETED` value.

Tests:
- Tests will be updated in one of the next issues with global tests refactoring.

### Related tickets

Part of #126

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
