### PR TITLE
feat: implement get all languages endpoint

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/language/GetLanguagesUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/language/GetLanguagesUseCaseImpl.java
@@ -1,0 +1,19 @@
+package ru.jerael.booktracker.backend.application.usecase.language;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.repository.LanguageRepository;
+import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguagesUseCase;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GetLanguagesUseCaseImpl implements GetLanguagesUseCase {
+    private final LanguageRepository languageRepository;
+
+    @Override
+    public List<Language> execute() {
+        return languageRepository.findAll();
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaLanguageRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaLanguageRepository.java
@@ -3,9 +3,12 @@ package ru.jerael.booktracker.backend.data.db.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.LanguageEntity;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface JpaLanguageRepository extends JpaRepository<LanguageEntity, String> {
     Optional<LanguageEntity> findByCode(String code);
+
+    List<LanguageEntity> findAllByOrderByNameAsc();
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
@@ -17,7 +17,7 @@ public class LanguageRepositoryImpl implements LanguageRepository {
 
     @Override
     public List<Language> findAll() {
-        return jpaLanguageRepository.findAll().stream().map(languageDataMapper::toDomain).toList();
+        return jpaLanguageRepository.findAllByOrderByNameAsc().stream().map(languageDataMapper::toDomain).toList();
     }
 
     @Override

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/language/GetLanguagesUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/language/GetLanguagesUseCase.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.domain.usecase.language;
+
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import java.util.List;
+
+public interface GetLanguagesUseCase {
+    List<Language> execute();
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/LanguageController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/LanguageController.java
@@ -1,0 +1,29 @@
+package ru.jerael.booktracker.backend.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguagesUseCase;
+import ru.jerael.booktracker.backend.web.dto.language.LanguageResponse;
+import ru.jerael.booktracker.backend.web.mapper.LanguageWebMapper;
+import java.util.List;
+
+@Tag(name = "Languages")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/languages")
+public class LanguageController {
+    private final GetLanguagesUseCase getLanguagesUseCase;
+    private final LanguageWebMapper languageWebMapper;
+
+    @Operation(summary = "Get all languages")
+    @GetMapping
+    public List<LanguageResponse> getAll() {
+        List<Language> languages = getLanguagesUseCase.execute();
+        return languageWebMapper.toResponses(languages);
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
@@ -3,6 +3,7 @@ package ru.jerael.booktracker.backend.web.mapper;
 import org.springframework.stereotype.Component;
 import ru.jerael.booktracker.backend.domain.model.language.Language;
 import ru.jerael.booktracker.backend.web.dto.language.LanguageResponse;
+import java.util.List;
 
 @Component
 public class LanguageWebMapper {
@@ -13,5 +14,11 @@ public class LanguageWebMapper {
             language.code(),
             language.name()
         );
+    }
+
+    public List<LanguageResponse> toResponses(List<Language> languages) {
+        if (languages == null) return List.of();
+
+        return languages.stream().map(this::toResponse).toList();
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Added sorting for language list retrieving in `JpaLanguageRepository` and `LanguageRepositoryImpl`.
- Implemented `GetLanguagesUseCaseImpl`.
- Added mapper from languages to responses in `LanguageWebMapper`.
- Added `LanguageController` with `GET /api/v1/languages` endpoint.

Tests:
- Tests will be updated in one of the next issues with global tests refactoring.

### Related tickets

Part of #131

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
