### PR TITLE
feat: implement get language by code endpoint

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/application/usecase/language/GetLanguageByCodeUseCaseImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/application/usecase/language/GetLanguageByCodeUseCaseImpl.java
@@ -1,0 +1,19 @@
+package ru.jerael.booktracker.backend.application.usecase.language;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ru.jerael.booktracker.backend.domain.exception.factory.LanguageExceptionFactory;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.repository.LanguageRepository;
+import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguageByCodeUseCase;
+
+@Component
+@RequiredArgsConstructor
+public class GetLanguageByCodeUseCaseImpl implements GetLanguageByCodeUseCase {
+    private final LanguageRepository languageRepository;
+
+    @Override
+    public Language execute(String code) {
+        return languageRepository.findByCode(code).orElseThrow(() -> LanguageExceptionFactory.languageNotFound(code));
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/usecase/language/GetLanguageByCodeUseCase.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/usecase/language/GetLanguageByCodeUseCase.java
@@ -1,0 +1,7 @@
+package ru.jerael.booktracker.backend.domain.usecase.language;
+
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+
+public interface GetLanguageByCodeUseCase {
+    Language execute(String code);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/util/StringNormalizer.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/util/StringNormalizer.java
@@ -1,0 +1,9 @@
+package ru.jerael.booktracker.backend.domain.util;
+
+public class StringNormalizer {
+    public static String normalize(String s) {
+        if (s == null) return null;
+
+        return s.trim().toLowerCase();
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/LanguageController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/LanguageController.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguageByCodeUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguagesUseCase;
 import ru.jerael.booktracker.backend.web.dto.language.LanguageResponse;
 import ru.jerael.booktracker.backend.web.mapper.LanguageWebMapper;
@@ -18,6 +20,7 @@ import java.util.List;
 @RequestMapping("/api/v1/languages")
 public class LanguageController {
     private final GetLanguagesUseCase getLanguagesUseCase;
+    private final GetLanguageByCodeUseCase getLanguageByCodeUseCase;
     private final LanguageWebMapper languageWebMapper;
 
     @Operation(summary = "Get all languages")
@@ -25,5 +28,13 @@ public class LanguageController {
     public List<LanguageResponse> getAll() {
         List<Language> languages = getLanguagesUseCase.execute();
         return languageWebMapper.toResponses(languages);
+    }
+
+    @Operation(summary = "Get language by code")
+    @GetMapping("/{code}")
+    public LanguageResponse getByCode(@PathVariable String code) {
+        String normalizedCode = languageWebMapper.normalize(code);
+        Language language = getLanguageByCodeUseCase.execute(normalizedCode);
+        return languageWebMapper.toResponse(language);
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/controller/LanguageController.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/controller/LanguageController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.jerael.booktracker.backend.domain.model.language.Language;
 import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguageByCodeUseCase;
 import ru.jerael.booktracker.backend.domain.usecase.language.GetLanguagesUseCase;
+import ru.jerael.booktracker.backend.domain.util.StringNormalizer;
 import ru.jerael.booktracker.backend.web.dto.language.LanguageResponse;
 import ru.jerael.booktracker.backend.web.mapper.LanguageWebMapper;
 import java.util.List;
@@ -33,7 +34,7 @@ public class LanguageController {
     @Operation(summary = "Get language by code")
     @GetMapping("/{code}")
     public LanguageResponse getByCode(@PathVariable String code) {
-        String normalizedCode = languageWebMapper.normalize(code);
+        String normalizedCode = StringNormalizer.normalize(code);
         Language language = getLanguageByCodeUseCase.execute(normalizedCode);
         return languageWebMapper.toResponse(language);
     }

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
@@ -21,10 +21,4 @@ public class LanguageWebMapper {
 
         return languages.stream().map(this::toResponse).toList();
     }
-
-    public String normalize(String code) {
-        if (code == null) return null;
-
-        return code.trim().toLowerCase();
-    }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
+++ b/src/main/java/ru/jerael/booktracker/backend/web/mapper/LanguageWebMapper.java
@@ -21,4 +21,10 @@ public class LanguageWebMapper {
 
         return languages.stream().map(this::toResponse).toList();
     }
+
+    public String normalize(String code) {
+        if (code == null) return null;
+
+        return code.trim().toLowerCase();
+    }
 }


### PR DESCRIPTION
### What does this PR do?

- Implemented `GetLanguageByCodeUseCaseImpl`.
- Added `StringNormalizer` to Domain layer.
- Added `LanguageController` with `GET /api/v1/languages/{code}` endpoint.

Tests:
- Tests will be updated in one of the next issues with global tests refactoring.

### Related tickets

Closes #131

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
