### PR TITLE
feat: implement caching for genres and languages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ POSTGRES_DB=booktracker_db
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=replace-it-please
+REDIS_TTL=24h
 
 # Backend
 BACKEND_PORT=4000

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- MINIO -->
         <dependency>

--- a/src/main/java/ru/jerael/booktracker/backend/Application.java
+++ b/src/main/java/ru/jerael/booktracker/backend/Application.java
@@ -2,6 +2,7 @@ package ru.jerael.booktracker.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -9,7 +10,10 @@ import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.i18n.FixedLocaleResolver;
 import java.util.Locale;
 
-@SpringBootApplication(exclude = UserDetailsServiceAutoConfiguration.class)
+@SpringBootApplication(exclude = {
+    UserDetailsServiceAutoConfiguration.class,
+    DataRedisRepositoriesAutoConfiguration.class
+})
 @EnableAsync
 public class Application {
 

--- a/src/main/java/ru/jerael/booktracker/backend/data/config/RedisConfig.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/config/RedisConfig.java
@@ -1,0 +1,67 @@
+package ru.jerael.booktracker.backend.data.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import ru.jerael.booktracker.backend.domain.model.Genre;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.*;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class RedisConfig {
+    private final RedisProperties properties;
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory factory, ObjectMapper objectMapper) {
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(10));
+
+        Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+
+        configs.put("languages", collectionConfig(objectMapper, ArrayList.class, Language.class));
+        configs.put("language", singleConfig(objectMapper, Language.class));
+
+        configs.put("genres", collectionConfig(objectMapper, LinkedHashSet.class, Genre.class));
+        configs.put("genre", singleConfig(objectMapper, Genre.class));
+
+        return RedisCacheManager.builder(factory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(configs)
+            .build();
+    }
+
+    private RedisCacheConfiguration singleConfig(ObjectMapper mapper, Class<?> valueType) {
+        JavaType type = mapper.getTypeFactory().constructType(valueType);
+        return createConfig(mapper, type);
+    }
+
+    private RedisCacheConfiguration collectionConfig(
+        ObjectMapper mapper,
+        Class<? extends Collection> collectionClass,
+        Class<?> elementClass
+    ) {
+        JavaType type = mapper.getTypeFactory().constructCollectionType(collectionClass, elementClass);
+        return createConfig(mapper, type);
+    }
+
+    private RedisCacheConfiguration createConfig(ObjectMapper mapper, JavaType type) {
+        var serializer = new JacksonJsonRedisSerializer<>(mapper, type);
+        return RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(properties.getTtl())
+            .disableCachingNullValues()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+    }
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/config/RedisProperties.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/config/RedisProperties.java
@@ -1,0 +1,13 @@
+package ru.jerael.booktracker.backend.data.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import java.time.Duration;
+
+@Component
+@Data
+@ConfigurationProperties(prefix = "app.redis")
+public class RedisProperties {
+    private Duration ttl = Duration.ofHours(24);
+}

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImpl.java
@@ -1,6 +1,7 @@
 package ru.jerael.booktracker.backend.data.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.GenreEntity;
 import ru.jerael.booktracker.backend.data.db.repository.JpaGenreRepository;
@@ -19,12 +20,14 @@ public class GenreRepositoryImpl implements GenreRepository {
     private final JpaGenreRepository jpaGenreRepository;
     private final GenreDataMapper genreDataMapper;
 
+    @Cacheable(value = "genres", key = "'all'")
     @Override
     public Set<Genre> findAll() {
         List<GenreEntity> entities = jpaGenreRepository.findAllByOrderByNameAsc();
         return entities.stream().map(genreDataMapper::toDomain).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    @Cacheable(value = "genre", key = "#id")
     @Override
     public Optional<Genre> findById(Integer id) {
         return jpaGenreRepository.findById(id).map(genreDataMapper::toDomain);

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/GenreRepositoryImpl.java
@@ -27,7 +27,7 @@ public class GenreRepositoryImpl implements GenreRepository {
         return entities.stream().map(genreDataMapper::toDomain).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    @Cacheable(value = "genre", key = "#id")
+    @Cacheable(value = "genre", key = "#id", unless = "#result == null")
     @Override
     public Optional<Genre> findById(Integer id) {
         return jpaGenreRepository.findById(id).map(genreDataMapper::toDomain);

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
@@ -22,7 +22,7 @@ public class LanguageRepositoryImpl implements LanguageRepository {
         return jpaLanguageRepository.findAllByOrderByNameAsc().stream().map(languageDataMapper::toDomain).toList();
     }
 
-    @Cacheable(value = "language", key = "#code")
+    @Cacheable(value = "language", key = "#code", unless = "#result == null")
     @Override
     public Optional<Language> findByCode(String code) {
         return jpaLanguageRepository.findByCode(code).map(languageDataMapper::toDomain);

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/LanguageRepositoryImpl.java
@@ -1,6 +1,7 @@
 package ru.jerael.booktracker.backend.data.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.repository.JpaLanguageRepository;
 import ru.jerael.booktracker.backend.data.mapper.LanguageDataMapper;
@@ -15,11 +16,13 @@ public class LanguageRepositoryImpl implements LanguageRepository {
     private final JpaLanguageRepository jpaLanguageRepository;
     private final LanguageDataMapper languageDataMapper;
 
+    @Cacheable(value = "languages", key = "'all'")
     @Override
     public List<Language> findAll() {
         return jpaLanguageRepository.findAllByOrderByNameAsc().stream().map(languageDataMapper::toDomain).toList();
     }
 
+    @Cacheable(value = "language", key = "#code")
     @Override
     public Optional<Language> findByCode(String code) {
         return jpaLanguageRepository.findByCode(code).map(languageDataMapper::toDomain);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -87,3 +87,5 @@ app:
       access-expiry: ${AUTH_ACCESS_TOKEN_EXPIRY:10m}
       refresh-expiry: ${AUTH_REFRESH_TOKEN_EXPIRY:30d}
       issuer: ${AUTH_TOKEN_ISSUER}
+  redis:
+    ttl: ${REDIS_TTL:24h}

--- a/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/GenreCacheTest.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/GenreCacheTest.kt
@@ -1,0 +1,52 @@
+package ru.jerael.booktracker.backend.data.repository
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import ru.jerael.booktracker.backend.config.TestcontainersConfiguration
+import ru.jerael.booktracker.backend.data.db.repository.JpaGenreRepository
+import ru.jerael.booktracker.backend.factory.genre.GenreEntityFactory
+
+@SpringBootTest
+@Import(TestcontainersConfiguration::class)
+class GenreCacheTest {
+    
+    @Autowired
+    private lateinit var redisCacheManager: RedisCacheManager
+    
+    @MockitoSpyBean
+    private lateinit var jpaGenreRepository: JpaGenreRepository
+    
+    @Autowired
+    private lateinit var genreRepository: GenreRepositoryImpl
+    
+    @BeforeEach
+    fun setUp() {
+        redisCacheManager.getCache("genres")?.clear()
+        redisCacheManager.getCache("genre")?.clear()
+    }
+    
+    @Test
+    fun `findAll should cache set of genres and not call database again`() {
+        genreRepository.findAll()
+        genreRepository.findAll()
+        
+        verify(jpaGenreRepository, times(1)).findAllByOrderByNameAsc()
+    }
+    
+    @Test
+    fun `findById should cache genre and not call database again`() {
+        val genreId = jpaGenreRepository.save(GenreEntityFactory.createGenreEntity()).id
+        
+        genreRepository.findById(genreId)
+        genreRepository.findById(genreId)
+        
+        verify(jpaGenreRepository, times(1)).findById(genreId)
+    }
+}

--- a/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/GenreCacheTest.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/GenreCacheTest.kt
@@ -2,8 +2,7 @@ package ru.jerael.booktracker.backend.data.repository
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -43,6 +42,8 @@ class GenreCacheTest {
     @Test
     fun `findById should cache genre and not call database again`() {
         val genreId = jpaGenreRepository.save(GenreEntityFactory.createGenreEntity()).id
+        
+        reset(jpaGenreRepository)
         
         genreRepository.findById(genreId)
         genreRepository.findById(genreId)

--- a/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/LanguageCacheTest.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/LanguageCacheTest.kt
@@ -2,8 +2,7 @@ package ru.jerael.booktracker.backend.data.repository
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -43,6 +42,8 @@ class LanguageCacheTest {
     @Test
     fun `findByCode should cache language and not call database again`() {
         val code = jpaLanguageRepository.save(LanguageEntityFactory.createLanguageEntity()).code
+        
+        reset(jpaLanguageRepository)
         
         languageRepository.findByCode(code)
         languageRepository.findByCode(code)

--- a/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/LanguageCacheTest.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/LanguageCacheTest.kt
@@ -1,0 +1,52 @@
+package ru.jerael.booktracker.backend.data.repository
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import ru.jerael.booktracker.backend.config.TestcontainersConfiguration
+import ru.jerael.booktracker.backend.data.db.repository.JpaLanguageRepository
+import ru.jerael.booktracker.backend.factory.language.LanguageEntityFactory
+
+@SpringBootTest
+@Import(TestcontainersConfiguration::class)
+class LanguageCacheTest {
+    
+    @Autowired
+    private lateinit var redisCacheManager: RedisCacheManager
+    
+    @MockitoSpyBean
+    private lateinit var jpaLanguageRepository: JpaLanguageRepository
+    
+    @Autowired
+    private lateinit var languageRepository: LanguageRepositoryImpl
+    
+    @BeforeEach
+    fun setUp() {
+        redisCacheManager.getCache("languages")?.clear()
+        redisCacheManager.getCache("language")?.clear()
+    }
+    
+    @Test
+    fun `findAll should cache list of languages and not call database again`() {
+        languageRepository.findAll()
+        languageRepository.findAll()
+        
+        verify(jpaLanguageRepository, times(1)).findAllByOrderByNameAsc()
+    }
+    
+    @Test
+    fun `findByCode should cache language and not call database again`() {
+        val code = jpaLanguageRepository.save(LanguageEntityFactory.createLanguageEntity()).code
+        
+        languageRepository.findByCode(code)
+        languageRepository.findByCode(code)
+        
+        verify(jpaLanguageRepository, times(1)).findByCode(code)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Added `spring-boot-starter-cache` dependency to `pom.xml`.
- Added `REDIS_TTL` property to `.env` and `application.yaml`.
- Added `RedisConfig`.
- Made `Genre` and `Language` repositories cacheable.

Tests:
- Added `GenreCacheTest` and `LanguageCacheTest`.

### Related tickets

Closes #211

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.
3. Copy .env.example to .env.
4. Start the infrastructure: `docker compose -f docker-compose.dev.yml up --build -d`.
5. Run application:
    - **IDE:** Install plugin "EnvFile" and set .env file in Run Configuration.
    - **Terminal:**
        ```bash
        export $(grep -v '^#' .env | xargs) && ./mvnw spring-boot:run
        ```
6. Verify API via Swagger UI: `http://localhost:8080/swagger-ui.html`.

### Additional notes

no additional info
