### PR TITLE
feat: define domain models and Google Books API dtos

### DIFF
--- a/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/GoogleBookItem.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/GoogleBookItem.java
@@ -1,0 +1,8 @@
+package ru.jerael.booktracker.backend.data.external.google.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleBookItem(
+    VolumeInfo volumeInfo
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/GoogleBooksResponse.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/GoogleBooksResponse.java
@@ -1,0 +1,10 @@
+package ru.jerael.booktracker.backend.data.external.google.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleBooksResponse(
+    Integer totalItems,
+    List<GoogleBookItem> items
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/ImageLinks.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/ImageLinks.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.data.external.google.dto;
+
+public record ImageLinks(
+    String smallThumbnail,
+    String thumbnail
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/IndustryIdentifier.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/IndustryIdentifier.java
@@ -1,0 +1,6 @@
+package ru.jerael.booktracker.backend.data.external.google.dto;
+
+public record IndustryIdentifier(
+    String type,
+    String identifier
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/VolumeInfo.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/external/google/dto/VolumeInfo.java
@@ -1,0 +1,18 @@
+package ru.jerael.booktracker.backend.data.external.google.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VolumeInfo(
+    String title,
+    List<String> authors,
+    String publisher,
+    String publishedDate,
+    String description,
+    List<IndustryIdentifier> industryIdentifiers,
+    Integer pageCount,
+    List<String> categories,
+    ImageLinks imageLinks,
+    String language
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookMetadata.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookMetadata.java
@@ -1,0 +1,21 @@
+package ru.jerael.booktracker.backend.domain.model.book;
+
+import ru.jerael.booktracker.backend.domain.model.author.Author;
+import ru.jerael.booktracker.backend.domain.model.genre.Genre;
+import ru.jerael.booktracker.backend.domain.model.language.Language;
+import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
+import java.util.Set;
+
+public record BookMetadata(
+    String title,
+    String cover,
+    Set<Genre> genres,
+    Set<Author> authors,
+    String description,
+    Publisher publisher,
+    Language language,
+    Integer publishedOn,
+    Integer totalPages,
+    String isbn10,
+    String isbn13
+) {}

--- a/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookSearchQuery.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/model/book/BookSearchQuery.java
@@ -1,0 +1,5 @@
+package ru.jerael.booktracker.backend.domain.model.book;
+
+public record BookSearchQuery(
+    String isbn
+) {}


### PR DESCRIPTION
### What does this PR do?

- Added `BookMetadata` and `BookSearchQuery` domain models.
- Added `GoogleBooksResponse` dto with nested `GoogleBookItem`, `ImageLinks`, `IndustryIdentifier` and `VolumeInfo`.

### Related tickets

Part of #220

### Screenshots

not applicable

### How to test

no testing required

### Additional notes

no additional info
