### PR TITLE
feat: implement search by similarity in repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,12 +184,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa-test</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaAuthorRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaAuthorRepository.java
@@ -1,6 +1,9 @@
 package ru.jerael.booktracker.backend.data.db.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
 import java.util.List;
@@ -13,4 +16,15 @@ public interface JpaAuthorRepository extends JpaRepository<AuthorEntity, UUID> {
     Optional<AuthorEntity> findByFullNameIgnoreCase(String fullName);
 
     List<AuthorEntity> findAllByFullNameInIgnoreCase(Set<String> names);
+
+    @Query(
+        value = """
+            SELECT *, similarity(full_name, :query) AS rank
+            FROM authors
+            WHERE full_name % :query OR full_name ILIKE CONCAT('%', :query, '%')
+            ORDER BY rank DESC
+            """,
+        nativeQuery = true
+    )
+    List<AuthorEntity> searchBySimilarity(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaPublisherRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/db/repository/JpaPublisherRepository.java
@@ -1,12 +1,27 @@
 package ru.jerael.booktracker.backend.data.db.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface JpaPublisherRepository extends JpaRepository<PublisherEntity, UUID> {
     Optional<PublisherEntity> findByNameIgnoreCase(String name);
+
+    @Query(
+        value = """
+            SELECT *, similarity(name, :query) AS rank
+            FROM publishers
+            WHERE name % :query OR name ILIKE CONCAT('%', :query, '%')
+            ORDER BY rank DESC
+            """,
+        nativeQuery = true
+    )
+    List<PublisherEntity> searchBySimilarity(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImpl.java
@@ -1,12 +1,17 @@
 package ru.jerael.booktracker.backend.data.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.AuthorEntity;
 import ru.jerael.booktracker.backend.data.db.repository.JpaAuthorRepository;
 import ru.jerael.booktracker.backend.data.mapper.AuthorDataMapper;
 import ru.jerael.booktracker.backend.domain.model.author.Author;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
 import ru.jerael.booktracker.backend.domain.repository.AuthorRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,5 +39,21 @@ public class AuthorRepositoryImpl implements AuthorRepository {
         return jpaAuthorRepository.findAllByFullNameInIgnoreCase(names).stream()
             .map(authorDataMapper::toDomain)
             .collect(Collectors.toSet());
+    }
+
+    @Override
+    public PageResult<Author> searchByFullName(PageQuery pageQuery, String query) {
+        int page = pageQuery != null ? pageQuery.page() : 0;
+        int size = pageQuery != null ? pageQuery.size() : 5;
+        Pageable pageable = PageRequest.of(page, size);
+
+        List<AuthorEntity> entities = jpaAuthorRepository.searchBySimilarity(query, pageable);
+        return new PageResult<>(
+            entities.stream().map(authorDataMapper::toDomain).toList(),
+            size,
+            page,
+            entities.size(),
+            1
+        );
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImpl.java
+++ b/src/main/java/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImpl.java
@@ -1,12 +1,17 @@
 package ru.jerael.booktracker.backend.data.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import ru.jerael.booktracker.backend.data.db.entity.PublisherEntity;
 import ru.jerael.booktracker.backend.data.db.repository.JpaPublisherRepository;
 import ru.jerael.booktracker.backend.data.mapper.PublisherDataMapper;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
 import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
 import ru.jerael.booktracker.backend.domain.repository.PublisherRepository;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -25,5 +30,21 @@ public class PublisherRepositoryImpl implements PublisherRepository {
         PublisherEntity entity = publisherDataMapper.toEntity(publisher);
         PublisherEntity savedEntity = jpaPublisherRepository.save(entity);
         return publisherDataMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public PageResult<Publisher> searchByName(PageQuery pageQuery, String query) {
+        int page = pageQuery != null ? pageQuery.page() : 0;
+        int size = pageQuery != null ? pageQuery.size() : 5;
+        Pageable pageable = PageRequest.of(page, size);
+
+        List<PublisherEntity> entities = jpaPublisherRepository.searchBySimilarity(query, pageable);
+        return new PageResult<>(
+            entities.stream().map(publisherDataMapper::toDomain).toList(),
+            size,
+            page,
+            entities.size(),
+            1
+        );
     }
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/AuthorRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/AuthorRepository.java
@@ -1,6 +1,8 @@
 package ru.jerael.booktracker.backend.domain.repository;
 
 import ru.jerael.booktracker.backend.domain.model.author.Author;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
 import java.util.Optional;
 import java.util.Set;
 
@@ -10,4 +12,6 @@ public interface AuthorRepository {
     Author save(Author author);
 
     Set<Author> findAllByNames(Set<String> names);
+
+    PageResult<Author> searchByFullName(PageQuery pageQuery, String query);
 }

--- a/src/main/java/ru/jerael/booktracker/backend/domain/repository/PublisherRepository.java
+++ b/src/main/java/ru/jerael/booktracker/backend/domain/repository/PublisherRepository.java
@@ -1,5 +1,7 @@
 package ru.jerael.booktracker.backend.domain.repository;
 
+import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery;
+import ru.jerael.booktracker.backend.domain.model.pagination.PageResult;
 import ru.jerael.booktracker.backend.domain.model.publisher.Publisher;
 import java.util.Optional;
 
@@ -7,4 +9,6 @@ public interface PublisherRepository {
     Optional<Publisher> findByName(String name);
 
     Publisher save(Publisher publisher);
+
+    PageResult<Publisher> searchByName(PageQuery pageQuery, String query);
 }

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -67,3 +67,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/33__rename-read-status-to-completed.yaml
   - include:
       file: classpath:/db/changelog/changes/34__enable-pg_trgm.yaml
+  - include:
+      file: classpath:/db/changelog/changes/35__add-gin-index-to-authors.yaml
+  - include:
+      file: classpath:/db/changelog/changes/36__add-gin-index-to-publishers.yaml

--- a/src/main/resources/db/changelog/changelog-master.yaml
+++ b/src/main/resources/db/changelog/changelog-master.yaml
@@ -65,3 +65,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/32__change-published_on-type-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/33__rename-read-status-to-completed.yaml
+  - include:
+      file: classpath:/db/changelog/changes/34__enable-pg_trgm.yaml

--- a/src/main/resources/db/changelog/changes/34__enable-pg_trgm.yaml
+++ b/src/main/resources/db/changelog/changes/34__enable-pg_trgm.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 34__enable-pg_trgm
+      author: Jerael
+      comment: enable pg_trgm extension
+      changes:
+        - sql:
+            sql: |
+              CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/src/main/resources/db/changelog/changes/35__add-gin-index-to-authors.yaml
+++ b/src/main/resources/db/changelog/changes/35__add-gin-index-to-authors.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 35__add-gin-index-to-authors
+      author: Jerael
+      comment: add gin index to authors
+      changes:
+        - sql:
+            sql: |
+              CREATE INDEX IF NOT EXISTS idx_authors_full_name ON authors USING gin (full_name gin_trgm_ops);

--- a/src/main/resources/db/changelog/changes/36__add-gin-index-to-publishers.yaml
+++ b/src/main/resources/db/changelog/changes/36__add-gin-index-to-publishers.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 36__add-gin-index-to-publishers
+      author: Jerael
+      comment: add gin index to publishers
+      changes:
+        - sql:
+            sql: |
+              CREATE INDEX IF NOT EXISTS idx_publishers_name ON publishers USING gin (name gin_trgm_ops);

--- a/src/test/kotlin/ru/jerael/booktracker/backend/config/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/config/TestcontainersConfiguration.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.DynamicPropertyRegistrar
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 @TestConfiguration(proxyBeanMethods = false)
@@ -38,5 +39,11 @@ class TestcontainersConfiguration {
     fun redisContainer(): GenericContainer<*> {
         return GenericContainer(DockerImageName.parse("redis:8.4.2-alpine3.22"))
             .withExposedPorts(6379)
+    }
+    
+    @Bean
+    @ServiceConnection(name = "postgres")
+    fun postgresContainer(): PostgreSQLContainer<*> {
+        return PostgreSQLContainer(DockerImageName.parse("postgres:17.4-alpine"))
     }
 }

--- a/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImplTest.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/AuthorRepositoryImplTest.kt
@@ -10,6 +10,8 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.context.annotation.Import
 import ru.jerael.booktracker.backend.data.db.repository.JpaAuthorRepository
 import ru.jerael.booktracker.backend.data.mapper.AuthorDataMapper
+import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery
+import ru.jerael.booktracker.backend.domain.model.pagination.SortDirection
 import ru.jerael.booktracker.backend.factory.author.AuthorDomainFactory
 import ru.jerael.booktracker.backend.factory.author.AuthorEntityFactory
 
@@ -77,6 +79,31 @@ class AuthorRepositoryImplTest {
         with(result) {
             assertThat(size).isEqualTo(2)
             assertThat(this).extracting("fullName").containsExactlyInAnyOrder("Author A", "Author B")
+        }
+    }
+    
+    @Test
+    fun `searchByFullName should return list of found authors by similarity`() {
+        jpaAuthorRepository.saveAll(
+            listOf(
+                AuthorEntityFactory.createAuthorEntity(id = null, fullName = "Author A"),
+                AuthorEntityFactory.createAuthorEntity(id = null, fullName = "Brandon Sanderson"),
+                AuthorEntityFactory.createAuthorEntity(id = null, fullName = "Robert Jordan")
+            )
+        )
+        val query = "er"
+        val pageQuery = PageQuery(0, 5, "fullName", SortDirection.ASC)
+        
+        val result = authorRepository.searchByFullName(pageQuery, query)
+        
+        with(result) {
+            assertThat(content).hasSize(2)
+            
+            val authorNames = content.map { it.fullName }
+            assertThat(authorNames).containsExactlyInAnyOrder("Brandon Sanderson", "Robert Jordan")
+            assertThat(authorNames).doesNotContain("Author A")
+            
+            assertThat(totalElements).isEqualTo(2)
         }
     }
 }

--- a/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImplTest.kt
+++ b/src/test/kotlin/ru/jerael/booktracker/backend/data/repository/PublisherRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package ru.jerael.booktracker.backend.data.repository
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
@@ -8,6 +9,8 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.context.annotation.Import
 import ru.jerael.booktracker.backend.data.db.repository.JpaPublisherRepository
 import ru.jerael.booktracker.backend.data.mapper.PublisherDataMapper
+import ru.jerael.booktracker.backend.domain.model.pagination.PageQuery
+import ru.jerael.booktracker.backend.domain.model.pagination.SortDirection
 import ru.jerael.booktracker.backend.factory.publisher.PublisherDomainFactory
 import ru.jerael.booktracker.backend.factory.publisher.PublisherEntityFactory
 
@@ -52,5 +55,30 @@ class PublisherRepositoryImplTest {
         
         assertEquals(savedPublisher.id, result.id)
         assertEquals(updatedPublisher.name, result.name)
+    }
+    
+    @Test
+    fun `searchByName should return list of found publishers by similarity`() {
+        jpaPublisherRepository.saveAll(
+            listOf(
+                PublisherEntityFactory.createPublisherEntity(name = "Publisher A"),
+                PublisherEntityFactory.createPublisherEntity(name = "Tor Books"),
+                PublisherEntityFactory.createPublisherEntity(name = "Aboba Books")
+            )
+        )
+        val query = "book"
+        val pageQuery = PageQuery(0, 5, "name", SortDirection.ASC)
+        
+        val result = publisherRepository.searchByName(pageQuery, query)
+        
+        with(result) {
+            assertThat(content).hasSize(2)
+            
+            val publisherNames = content.map { it.name }
+            assertThat(publisherNames).containsExactlyInAnyOrder("Tor Books", "Aboba Books")
+            assertThat(publisherNames).doesNotContain("Publisher A")
+            
+            assertThat(totalElements).isEqualTo(2)
+        }
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,10 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
-    username: test
-    password: test
-
   liquibase:
     change-log: classpath:/db/changelog/test-changelog-master.yaml
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,4 +1,9 @@
 spring:
+  datasource:
+    url: jdbc:tc:postgresql:17.4-alpine:///test
+    hikari:
+      maximum-pool-size: 2
+
   liquibase:
     change-log: classpath:/db/changelog/test-changelog-master.yaml
 

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -51,3 +51,5 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/32__change-published_on-type-in-books.yaml
   - include:
       file: classpath:/db/changelog/changes/33__rename-read-status-to-completed.yaml
+  - include:
+      file: classpath:/db/changelog/changes/34__enable-pg_trgm.yaml

--- a/src/test/resources/db/changelog/test-changelog-master.yaml
+++ b/src/test/resources/db/changelog/test-changelog-master.yaml
@@ -53,3 +53,7 @@ databaseChangeLog:
       file: classpath:/db/changelog/changes/33__rename-read-status-to-completed.yaml
   - include:
       file: classpath:/db/changelog/changes/34__enable-pg_trgm.yaml
+  - include:
+      file: classpath:/db/changelog/changes/35__add-gin-index-to-authors.yaml
+  - include:
+      file: classpath:/db/changelog/changes/36__add-gin-index-to-publishers.yaml


### PR DESCRIPTION
### What does this PR do?

- Added migration to enable `pg_trgm` extension.
- Added `GIN` index to `authors` and `publishers` tables.
- Added `testcontainers postgresql` dependency to `pom.xml`.
- Removed `h2` dependency from `pom.xml`.
- Implemented search by full name in `AuthorRepositoryImpl`.
- Implemented search by name in `PublisherRepositoryImpl`.

Tests:
- Added `PostgreSQLContainer` bean to `TestcontainersConfiguration`.
- Added postgresql test properties to `application.yaml`.
- Added test for `searchByFullName` to `AuthorRepositoryImplTest`.
- Added test for `searchByName` to `PublisherRepositoryImplTest`.

### Related tickets

Part of #225

### Screenshots

not applicable

### How to test

1. Clone the branch.
2. Run `mvnw test` for tests.

### Additional notes

no additional info
